### PR TITLE
Cleanup quickstart role tasks

### DIFF
--- a/OCP-4.X/roles/quickstart/tasks/main.yml
+++ b/OCP-4.X/roles/quickstart/tasks/main.yml
@@ -8,46 +8,8 @@
     path: /root/.kube
     state: directory
 
-    #- name: masters
-    #shell: oc get nodes | grep master | awk '{print $1}'
-    #register: ocp_masters
-
 - name: copy the kubeconfig
   copy:
     src: "{{ workdir }}/auth/kubeconfig"
     dest: /root/.kube/config
     remote_src: true
-
-- name: stat svt repo
-  stat:
-    path: /root/svt
-  register: svt
-
-- name: delete svt repo if exists
-  file:
-    path: /root/svt
-    state: absent
-  when: svt.stat.exists == True
-
-- name: clone svt repo
-  git:
-    repo: https://github.com/chaitanyaenr/svt
-    dest: /root/svt
-    update: yes
-    version: containerozed_tooling
-
-- name: create clusterloader dir
-  file:
-    path: /usr/libexec/atomic-openshift/
-    state: directory
-
-    #- name: pull down clusterloader binary
-    #get_url:
-    #url: "{{ CLUSTERLOADER_URL }}"
-    #dest: /usr/libexec/atomic-openshift/
-    #mode: 0755
-    #- name: copy clusterloader binary
-    #copy:
-    #src: /usr/bin/openshift-tests
-    #dest: /usr/libexec/atomic-openshift/extended.test
-    #mode: 0755


### PR DESCRIPTION
The tasks are no longer needed as we are using workloads framework
and clusterloader is part of the scale-ci-workload image.