### PR TITLE
change from tojson to to_json - for systems where newer version of jinja is not available.

### DIFF
--- a/OCP-4.X/roles/install-on-aws/templates/install-config.yaml.j2
+++ b/OCP-4.X/roles/install-on-aws/templates/install-config.yaml.j2
@@ -35,6 +35,6 @@ platform:
   aws:
     region: {{ aws_region }}
 pullSecret: |+
-  {{ openshift_install_pull_secret | tojson }}
+  {{ openshift_install_pull_secret | to_json }}
 sshKey: |+
   {{ install_ssh_pub_key.content| b64decode }}


### PR DESCRIPTION
On systems where it is not possible to upgrade jinja2 installer will fail as module
`tojson` is not part of jinja installation. This is case for RHEL 7/Centos 7 which deliver
python36-jinja2-2.8.1-2.el7.noarch
python-jinja2-2.7.2-4.el7.noarch

eg ansible issue : https://github.com/ansible/ansible/issues/25381

Fedora 30 is not affected with this problem