### PR TITLE
Add support to install ocp on google cloud

### DIFF
--- a/OCP-4.X/install-on-gcp.yml
+++ b/OCP-4.X/install-on-gcp.yml
@@ -1,0 +1,87 @@
+---
+#
+# IPI install of OCP 4 on Google cloud
+#
+
+- name: Perform IPI install OCP 4 on Google cloud
+  hosts: orchestration
+  gather_facts: true
+  remote_user: "{{orchestration_user}}"
+  vars_files:
+    - vars/install-on-gcp.yml
+  vars:
+    platform: "gcp"
+  roles:
+    - role: cleanup-on-gcp
+      when: openshift_cleanup|bool
+    - role: install-on-gcp
+      when: openshift_install|bool
+    - role: post-install
+      when: openshift_post_install|bool
+    - role: post-config-on-gcp
+      when: openshift_post_config|bool
+
+- name: (Optional) Debugging configuration of workload node
+  hosts: workload
+  gather_facts: true
+  remote_user: core
+  vars_files:
+    - vars/install-on-gcp.yml
+  roles:
+    - role: node-debug-config
+      when: openshift_debug_config|bool
+  post_tasks:
+    - name: Add other nodes to in-memory inventory
+      when: openshift_debug_config|bool
+      block:
+        - name: Get master nodes
+          shell: |
+            oc get nodes --no-headers -l 'node-role.kubernetes.io/master=' | awk '{print $1}'
+          register: ocp_master_nodes
+
+        - name: Get infra nodes
+          shell: |
+            oc get nodes --no-headers -l 'node-role.kubernetes.io/infra=' | awk '{print $1}'
+          register: ocp_infra_nodes
+
+        - name: Get worker nodes
+          shell: |
+            oc get nodes --no-headers -l 'node-role.kubernetes.io/worker=' | awk '{print $1}'
+          register: ocp_worker_nodes
+
+        - name: Add master nodes to in-memory inventory
+          add_host:
+            name: "{{ item }}"
+            groups: master
+            ansible_ssh_common_args: |-
+              -o ProxyCommand='ssh -i {{ansible_private_key_file}} -W %h:%p core@{{inventory_hostname}}'
+          with_items:
+            - "{{ ocp_master_nodes.stdout_lines }}"
+
+        - name: Add infra nodes to in-memory inventory
+          add_host:
+            name: "{{ item }}"
+            groups: infra
+            ansible_ssh_common_args: |-
+              -o ProxyCommand='ssh -i {{ansible_private_key_file}} -W %h:%p core@{{inventory_hostname}}'
+          with_items:
+            - "{{ ocp_infra_nodes.stdout_lines }}"
+
+        - name: Add worker nodes to in-memory inventory
+          add_host:
+            name: "{{ item }}"
+            groups: worker
+            ansible_ssh_common_args: |-
+              -o ProxyCommand='ssh -i {{ansible_private_key_file}} -W %h:%p core@{{inventory_hostname}}'
+          with_items:
+            - "{{ ocp_worker_nodes.stdout_lines }}"
+
+- name: (Optional) Debugging configuration of initially deployed nodes
+  hosts: master, infra, worker
+  gather_facts: true
+  remote_user: core
+  vars_files:
+    - vars/install-on-gcp.yml
+  roles:
+    - role: node-debug-config
+      when: openshift_debug_config|bool

--- a/OCP-4.X/roles/cleanup-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-gcp/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+#
+# Clean up GCP  IPI install
+#
+
+- name: Cleanup GCP cluster
+  shell: |
+    cd {{ansible_user_dir}}/scale-ci-deploy
+    export GOOGLE_CREDENTIALS={{ gcp_auth_key_file }}
+    bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
+
+- name: Clean scale-ci-deploy openshift-install directories
+  become: true
+  file:
+    path: "{{item}}"
+    state: absent
+  with_items:
+    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp"

--- a/OCP-4.X/roles/install-on-gcp/files/google-cloud-sdk.repo
+++ b/OCP-4.X/roles/install-on-gcp/files/google-cloud-sdk.repo
@@ -1,0 +1,8 @@
+[google-cloud-sdk]
+name=Google Cloud SDK
+baseurl=https://packages.cloud.google.com/yum/repos/cloud-sdk-el7-x86_64
+enabled=1
+gpgcheck=1
+repo_gpgcheck=1
+gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
+       https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg

--- a/OCP-4.X/roles/install-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-gcp/tasks/main.yml
@@ -1,0 +1,161 @@
+---
+#
+# Tasks to install OCP on GCP
+#
+# Flow:
+# * Setup directories and oc/kubectl client
+# * Either extract install binary or build from source
+# * Install cloud tools and authentication
+# * Install cluster
+#
+
+- name: Create scale-ci-deploy directories
+  file:
+    path: "{{item}}"
+    state: directory
+  with_items:
+    - "{{ansible_user_dir}}/scale-ci-deploy/"
+    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp"
+    - "{{ansible_user_dir}}/scale-ci-deploy/logs"
+    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+    - "{{ansible_user_dir}}/.docker"
+
+- name: Download oc client tools
+  get_url:
+    url: "{{openshift_client_location}}"
+    dest: "{{ansible_user_dir}}/scale-ci-deploy/{{openshift_client_location | basename}}"
+
+- name: Untar and install oc client tools
+  become: true
+  shell: |
+    set -o pipefail
+    cd {{ansible_user_dir}}/scale-ci-deploy/
+    tar xzf {{ansible_user_dir}}/scale-ci-deploy/{{openshift_client_location | basename}}
+    cp {{ansible_user_dir}}/scale-ci-deploy/oc /usr/local/bin/oc
+    cp {{ansible_user_dir}}/scale-ci-deploy/kubectl /usr/local/bin/kubectl
+
+- name: Setup config for container registry
+  template:
+    src: registry_auth.j2
+    dest: "{{ansible_user_dir}}/.docker/config.json"
+
+- name: Setup google cloud sdk repo
+  become: true
+  copy:
+    src: "{{ role_path }}/files/google-cloud-sdk.repo"
+    dest: /etc/yum.repos.d/
+    remote_src: true
+
+- name: Install dependencies
+  package:
+    name: "{{ packages }}"
+    state: latest
+    lock_timeout: 180
+  vars:
+    packages:
+      - google-cloud-sdk
+      - golang
+      - golang-bin
+
+- name: Use installer from a build
+  block:
+    - name: Extract openshift-install binary from the payload
+      shell: |
+        set -o pipefail
+        cd {{ansible_user_dir}}/scale-ci-deploy/bin
+        oc adm release extract --tools {{openshift_install_release_image_override}}
+        find -name \*.tar.gz -exec tar -xvf {} \;
+        chmod +x openshift-install
+  when: not openshift_install_installer_from_source|bool
+
+- name: Build installer from source
+  block:
+    - name: Create gopath dir
+      file:
+        path: "{{ gopath }}"
+        state: directory
+
+    - name: Set workdir
+      set_fact:
+        workdir: "{{ gopath }}/src/github.com/openshift/installer"
+
+    - name: Cleanup installer code if it exists
+      file:
+        path: "{{ workdir }}"
+        state: absent
+
+    - name: Clone installer repo
+      git:
+        repo: 'https://github.com/openshift/installer.git'
+        dest: "{{ workdir }}"
+        version: "{{ openshift_install_installer_from_source_version }}"
+
+    - name: Build installer binary
+      shell: |
+        cd {{ workdir }}
+        hack/build.sh
+      environment:
+        GOPATH: "{{ gopath }}"
+
+    - name: Copy installer into expected directory
+      copy:
+        src: "{{ workdir }}/bin/openshift-install"
+        dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/openshift-install"
+        remote_src: true
+        mode: 0744
+  when: openshift_install_installer_from_source|bool
+
+- name: Create .gcp dir
+  file:
+    path: "{{ ansible_user_dir }}/.gcp"
+    state: directory
+
+- name: Login GCP account via service account (For GCP CLI interactions) and set the default project
+  shell: |
+    gcloud auth activate-service-account {{ gcp_service_account }} --key-file={{ gcp_auth_key_file }} --project={{ gcp_project }}
+
+- name: Read contents of local ssh public key
+  slurp:
+    src: "{{openshift_install_ssh_pub_key_file}}"
+  delegate_to: localhost
+  register: install_ssh_pub_key
+
+- name: Setup install-config.yaml
+  template:
+    src: install-config.yaml.j2
+    dest: "{{item}}"
+  with_items:
+    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/install-config.yaml"
+    - "{{ansible_user_dir}}/scale-ci-deploy/install-config_gcp.yaml"
+
+- name: Run openshift-install on GCP using the image override
+  shell: |
+    set -o pipefail
+    cd {{ansible_user_dir}}/scale-ci-deploy
+    export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
+    export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
+    export GOOGLE_CREDENTIALS={{ gcp_auth_key_file }}
+    bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
+
+- name: Ensure that .kube dir exists
+  become: "{{item.become}}"
+  file:
+    path: "{{item.path}}"
+    state: directory
+  with_items:
+    - path: /root/.kube
+      become: true
+    - path: "{{ansible_user_dir}}/.kube"
+      become: false
+
+- name: Copy the kubeconfig to .kube directories
+  become: "{{item.become}}"
+  copy:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/auth/kubeconfig"
+    dest: "{{item.dest}}"
+    remote_src: true
+  with_items:
+    - dest: /root/.kube/config
+      become: true
+    - dest: "{{ansible_user_dir}}/.kube/config"
+      become: false

--- a/OCP-4.X/roles/install-on-gcp/templates/install-config.yaml.j2
+++ b/OCP-4.X/roles/install-on-gcp/templates/install-config.yaml.j2
@@ -1,0 +1,35 @@
+apiVersion: {{ openshift_install_apiversion }}
+baseDomain: {{ openshift_base_domain }}
+compute:
+- hyperthreading: Enabled
+  name: worker
+  platform: 
+    gcp:
+      type: {{ openshift_worker_machine_type }}
+  replicas: {{ openshift_worker_count }}
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  platform:
+    gcp:
+      type: {{ openshift_master_machine_type }}
+  replicas: {{ openshift_master_count }}
+metadata:
+  creationTimestamp: null
+  name: {{ openshift_cluster_name }}
+networking:
+  clusterNetwork:
+  - cidr: {{ openshift_cidr }}
+    hostPrefix: {{ openshift_host_prefix }}
+  machineCIDR: {{ openshift_machine_cidr }}
+  networkType: OpenShiftSDN
+  serviceNetwork:
+  - {{ openshift_service_network }}
+platform:
+  gcp:
+    projectID: {{ gcp_project }}
+    region: {{ gcp_region }}
+pullSecret: |+
+  {{ openshift_install_pull_secret | to_json }}
+sshKey: |+
+  {{ install_ssh_pub_key.content| b64decode }}

--- a/OCP-4.X/roles/install-on-gcp/templates/registry_auth.j2
+++ b/OCP-4.X/roles/install-on-gcp/templates/registry_auth.j2
@@ -1,0 +1,10 @@
+{
+	"auths": {
+		"quay.io": {
+			"auth": "{{ openshift_install_quay_registry_token }}"
+		},
+		"{{ openshift_install_image_registry }}": {
+			"auth": "{{ openshift_install_registry_token }}"
+		}
+	}
+}

--- a/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+#
+# Post-Config for OCP on GCP
+#
+# Performs:
+# * Opens firewall rules for workload/worker nodes for ssh (as well as for debugging workload pod ssh)
+# * Opens firewall rules for Network Tests P2P HostNetwork Tests
+#   Ports 2022 (tcp), 20000-20109 (tcp, udp), 32768-60999 (tcp, udp)
+#
+
+- name: Get cluster name
+  shell: |
+    {%raw%}oc get machineset -n openshift-machine-api -o=go-template='{{(index (index .items 0).metadata.labels {%endraw%} "{{machineset_metadata_label_prefix}}/cluster-api-cluster" {%raw%})}}'{%endraw%}
+  register: rhcos_cluster_name
+
+- name: Get public ip of the workload node
+  shell: |
+    oc get nodes -o wide | grep workload | awk '{print $7}'
+  register: workload_public_ip
+
+- name: Add workload node to group
+  add_host:
+    name: "{{ workload_public_ip.stdout }}"
+    groups: workload
+
+- name: Get network name
+  shell: |
+     gcloud compute networks list | grep {{ rhcos_cluster_name.stdout }} | awk '{print $1}' 
+  register: gcp_network
+
+- name: Create firewall rule for ICMP
+  shell: |
+    gcloud compute firewall-rules create scale-ci-icmp-{{ rhcos_cluster_name }} --network {{ gcp_network.stdout }} --priority 101 --description "scale-ci allow icmp" --allow icmp
+
+- name: Create firewall rule for ssh (22)
+  shell: |
+    gcloud compute firewall-rules create scale-ci-ssh-{{ rhcos_cluster_name }} --network {{ gcp_network.stdout }} --direction INGRESS --priority 102 --description "scale-ci allow ssh" --allow tcp:22
+
+- name: Create firewall rule for pbench-agent ssh (2022)
+  shell: |
+    gcloud compute firewall-rules create scale-ci-pbench-{{ rhcos_cluster_name }} --network {{ gcp_network.stdout }} --direction INGRESS --priority 103 --description "scale-ci allow pbench-agents" --allow tcp:2022
+
+- name: Create firewall rule for tcp,udp network tests (20000-20109)
+  shell: |
+    gcloud compute firewall-rules create scale-ci-net-{{ rhcos_cluster_name }} --network {{ gcp_network.stdout }} --direction INGRESS --priority 104 --description "scale-ci allow tcp,udp network tests" --rules tcp,udp:20000-20109 --action allow
+
+# Typically `net.ipv4.ip_local_port_range` is set to `32768 60999` in which uperf will pick a few random ports to send flags over.
+# Currently there is no method outside of sysctls to control those ports
+# See pbench issue #1238 - https://github.com/distributed-system-analysis/pbench/issues/1238
+
+- name: Create firewall rule for tcp,udp hostnetwork tests (32768-60999)
+  shell: |
+    gcloud compute firewall-rules create scale-ci-hostnet-{{ rhcos_cluster_name }} --network {{ gcp_network.stdout }}  --priority 105 --description "scale-ci allow tcp,udp hostnetwork tests" --rules tcp,udp:32768-60999 --action allow
+
+- name: Get the kubeconfig off of the orchestration host
+  fetch:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/auth/kubeconfig"
+    dest: "{{playbook_dir}}/kubeconfig"
+    flat: true
+  when:
+    - kubeconfig_auth_dir_path == ""
+

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -69,6 +69,22 @@
           toggle: "{{openshift_toggle_workload_node}}"
   when: platform == "azure"
 
+- name: GCP block of tasks
+  block:
+    - name: (GCP) Template out machineset yamls
+      template:
+        src: "{{item.src}}"
+        dest: "{{item.dest}}"
+      when: item.toggle|bool
+      with_items:
+        - src: gcp-infra-node-machineset.yml.j2
+          dest: "{{ansible_user_dir}}/scale-ci-deploy/infra-node-machineset.yml"
+          toggle: "{{openshift_toggle_infra_node}}"
+        - src: gcp-workload-node-machineset.yml.j2
+          dest: "{{ansible_user_dir}}/scale-ci-deploy/workload-node-machineset.yml"
+          toggle: "{{openshift_toggle_workload_node}}"
+  when: platform == "gcp"
+
 - name: (OSP) Template out machineset yamls
   template:
     src: "{{item.src}}"

--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -1,0 +1,196 @@
+apiVersion: v1
+items:
+- apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    generation: 1
+    labels:
+      {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
+    name: {{cluster_name.stdout}}-infra-a
+    namespace: openshift-machine-api
+    selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/{{cluster_name.stdout}}-infra-a
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
+        {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
+        {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-a
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
+          {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
+          {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-a
+      spec:
+        metadata:
+          creationTimestamp: null
+          labels:
+            node-role.kubernetes.io/infra: ""
+        providerSpec:
+          value:
+            apiVersion: gcpprovider.openshift.io/v1beta1
+            canIPForward: false
+            credentialsSecret:
+              name: gcp-cloud-credentials
+            deletionProtection: false
+            disks:
+            - autoDelete: false
+              boot: true
+              image: {{cluster_name.stdout}}-rhcos-image
+              labels: null
+              sizeGb: {{openshift_infra_node_volume_size}}
+              type: {{openshift_infra_node_volume_type}}
+            kind: GCPMachineProviderSpec
+            machineType: {{openshift_infra_node_machine_type}}
+            metadata:
+              creationTimestamp: null
+            networkInterfaces:
+            - network: {{cluster_name.stdout}}-network
+              subnetwork: {{cluster_name.stdout}}-worker-subnet
+            projectID: {{ gcp_project }}
+            region: {{ gcp_region }}
+            serviceAccounts:
+            - email: {{cluster_name.stdout}}-w@{{ gcp_service_account_email }}
+              scopes:
+              - https://www.googleapis.com/auth/cloud-platform
+            tags:
+            - {{cluster_name.stdout}}-infra
+            userDataSecret:
+              name: worker-user-data
+            zone: {{ gcp_region }}-a
+  status:
+    replicas: 1
+- apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    generation: 1
+    labels:
+      {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
+    name: {{cluster_name.stdout}}-infra-b
+    namespace: openshift-machine-api
+    selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/{{cluster_name.stdout}}-infra-b
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
+        {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
+        {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-b
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
+          {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
+          {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-b
+      spec:
+        metadata:
+          creationTimestamp: null
+          labels:
+            node-role.kubernetes.io/infra: ""
+        providerSpec:
+          value:
+            apiVersion: gcpprovider.openshift.io/v1beta1
+            canIPForward: false
+            credentialsSecret:
+              name: gcp-cloud-credentials
+            deletionProtection: false
+            disks:
+            - autoDelete: false
+              boot: true
+              image: {{cluster_name.stdout}}-rhcos-image
+              labels: null
+              sizeGb: {{openshift_infra_node_volume_size}}
+              type: {{openshift_infra_node_volume_type}}
+            kind: GCPMachineProviderSpec
+            machineType: {{openshift_infra_node_machine_type}}
+            metadata:
+              creationTimestamp: null
+            networkInterfaces:
+            - network: {{cluster_name.stdout}}-network
+              subnetwork: {{cluster_name.stdout}}-worker-subnet
+            projectID: {{ gcp_project }}
+            region: {{ gcp_region }}
+            serviceAccounts:
+            - email: {{cluster_name.stdout}}-w@{{ gcp_service_account_email }}
+              scopes:
+              - https://www.googleapis.com/auth/cloud-platform
+            tags:
+            - {{cluster_name.stdout}}-infra
+            userDataSecret:
+              name: worker-user-data
+            zone: {{ gcp_region }}-b
+  status:
+    replicas: 1
+- apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    generation: 1
+    labels:
+      {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
+    name: {{cluster_name.stdout}}-infra-c
+    namespace: openshift-machine-api
+    selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/{{cluster_name.stdout}}-infra-c
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
+        {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
+        {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-c
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
+          {{machineset_metadata_label_prefix}}/cluster-api-machine-role: infra
+          {{machineset_metadata_label_prefix}}/cluster-api-machine-type: infra
+          {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-infra-c
+      spec:
+        metadata:
+          creationTimestamp: null
+          labels:
+            node-role.kubernetes.io/infra: ""
+        providerSpec:
+          value:
+            apiVersion: gcpprovider.openshift.io/v1beta1
+            canIPForward: false
+            credentialsSecret:
+              name: gcp-cloud-credentials
+            deletionProtection: false
+            disks:
+            - autoDelete: false
+              boot: true
+              image: {{cluster_name.stdout}}-rhcos-image
+              labels: null
+              sizeGb: {{openshift_infra_node_volume_size}}
+              type: {{openshift_infra_node_volume_type}}
+            kind: GCPMachineProviderSpec
+            machineType: {{openshift_infra_node_machine_type}}
+            metadata:
+              creationTimestamp: null
+            networkInterfaces:
+            - network: {{cluster_name.stdout}}-network
+              subnetwork: {{cluster_name.stdout}}-worker-subnet
+            projectID: {{ gcp_project }}
+            region: {{ gcp_region }}
+            serviceAccounts:
+            - email: {{cluster_name.stdout}}-w@{{ gcp_service_account_email }}
+              scopes:
+              - https://www.googleapis.com/auth/cloud-platform
+            tags:
+            - {{cluster_name.stdout}}-infra
+            userDataSecret:
+              name: worker-user-data
+            zone: {{ gcp_region }}-c
+  status:
+    replicas: 1
+kind: List
+metadata: {}

--- a/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
@@ -1,0 +1,65 @@
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  generation: 1
+  labels:
+    {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}} 
+  name: {{cluster_name.stdout}}-workload-a
+  namespace: openshift-machine-api
+  selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machinesets/{{cluster_name.stdout}}-workload-a
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
+      {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
+      {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
+      {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-a
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
+        {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
+        {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
+        {{machineset_metadata_label_prefix}}/cluster-api-machineset: {{cluster_name.stdout}}-workload-a
+    spec:
+      metadata:
+        creationTimestamp: null
+        labels:
+          node-role.kubernetes.io/workload: ""
+      providerSpec:
+        value:
+          apiVersion: gcpprovider.openshift.io/v1beta1
+          canIPForward: false
+          credentialsSecret:
+            name: gcp-cloud-credentials
+          deletionProtection: false
+          disks:
+          - autoDelete: false
+            boot: true
+            image: {{cluster_name.stdout}}-rhcos-image
+            labels: null
+            sizeGb: {{openshift_workload_node_volume_size}}
+            type: {{openshift_workload_node_volume_type}}
+          kind: GCPMachineProviderSpec
+          machineType: {{openshift_workload_node_machine_type}}
+          metadata:
+            creationTimestamp: null
+          networkInterfaces:
+          - network: {{cluster_name.stdout}}-network
+            subnetwork: {{cluster_name.stdout}}-worker-subnet
+            publicIP: true
+          projectID: {{ gcp_project }}
+          region: {{ gcp_region }}
+          serviceAccounts:
+          - email: {{cluster_name.stdout}}-w@{{ gcp_service_account_email }}
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform
+          tags:
+          - {{cluster_name.stdout}}-workload
+          userDataSecret:
+            name: worker-user-data
+          zone: {{ gcp_region }}-a
+status:
+  replicas: 1

--- a/OCP-4.X/vars/install-on-gcp.yml
+++ b/OCP-4.X/vars/install-on-gcp.yml
@@ -1,0 +1,86 @@
+---
+###############################################################################
+# Ansible SSH variables.
+###############################################################################
+ansible_public_key_file: "{{ lookup('env', 'PUBLIC_KEY')|default('~/.ssh/id_rsa.pub', true) }}"
+ansible_private_key_file: "{{ lookup('env', 'PRIVATE_KEY')|default('~/.ssh/id_rsa', true) }}"
+
+orchestration_user: "{{ lookup('env', 'ORCHESTRATION_USER')|default('root', true) }}"
+###############################################################################
+# IPI install on GCP variables.
+###############################################################################
+# Playbook flow control
+openshift_cleanup: "{{ lookup('env', 'OPENSHIFT_CLEANUP')|default(false, true) }}"
+openshift_install: "{{ lookup('env', 'OPENSHIFT_INSTALL')|default(true, true) }}"
+openshift_post_install: "{{ lookup('env', 'OPENSHIFT_POST_INSTALL')|default(true, true) }}"
+openshift_post_config: "{{ lookup('env', 'OPENSHIFT_POST_CONFIG')|default(true, true) }}"
+openshift_debug_config: "{{ lookup('env', 'OPENSHIFT_DEBUG_CONFIG')|default(false, true) }}"
+
+# Installation variables
+# Check https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ for latest client
+openshift_client_location: "{{ lookup('env', 'OPENSHIFT_CLIENT_LOCATION') }}"
+# Release payload
+openshift_install_release_image_override: "{{ lookup('env', 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE') }}"
+openshift_install_apiversion: "{{ lookup('env', 'OPENSHIFT_INSTALL_APIVERSION')|default('v1', true) }}"
+# ssh key for install-config
+openshift_install_ssh_pub_key_file: "{{ lookup('env', 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"
+# Secrets/Tokens for extract and installing
+openshift_install_pull_secret: "{{ lookup('env', 'OPENSHIFT_INSTALL_PULL_SECRET') }}"
+openshift_install_quay_registry_token: "{{ lookup('env', 'OPENSHIFT_INSTALL_QUAY_REGISTRY_TOKEN') }}"
+openshift_install_image_registry: "{{ lookup('env', 'OPENSHIFT_INSTALL_IMAGE_REGISTRY')| default('registry.svc.ci.openshift.org', true) }}"
+openshift_install_registry_token: "{{ lookup('env', 'OPENSHIFT_INSTALL_REGISTRY_TOKEN') }}"
+# Not recommended, however you can build the installer from source. (You run the risk of using a mismatched binary vs install payload)
+openshift_install_installer_from_source: "{{ lookup('env', 'OPENSHIFT_INSTALL_INSTALLER_FROM_SOURCE')|default(false, true) }}"
+openshift_install_installer_from_source_version: "{{ lookup('env', 'OPENSHIFT_INSTALL_INSTALLER_FROM_SOURCE_VERSION')|default('master', true) }}"
+gopath: "{{ lookup('env', 'GOPATH')|default('/root/.go', true) }}"
+
+# Cloud environment and authentication
+gcp_service_account: "{{ lookup('env', 'GCP_SERVICE_ACCOUNT') }}"
+gcp_service_account_email: "{{ lookup('env', 'GCP_SERVICE_ACCOUNT_EMAIL') }}"
+gcp_auth_key_file: "{{ lookup('env', 'GCP_AUTH_KEY_FILE') }}"
+gcp_project: "{{ lookup('env', 'GCP_PROJECT') }}"
+gcp_region: "{{ lookup('env', 'GCP_REGION') }}"
+
+# Cluster Configuration
+openshift_base_domain: "{{ lookup('env', 'OPENSHIFT_BASE_DOMAIN') }}"
+openshift_cluster_name: "{{ lookup('env', 'OPENSHIFT_CLUSTER_NAME') }}"
+
+openshift_master_count: "{{ lookup('env', 'OPENSHIFT_MASTER_COUNT')|default(3, true) }}"
+openshift_worker_count: "{{ lookup('env', 'OPENSHIFT_WORKER_COUNT')|default(5, true) }}"
+
+openshift_master_machine_type: "{{ lookup('env', 'OPENSHIFT_MASTER_MACHINE_TYPE')|default('n1-standard-4', true) }}"
+openshift_worker_machine_type: "{{ lookup('env', 'OPENSHIFT_WORKER_MACHINE_TYPE')|default('n1-standard-4', true) }}"
+
+openshift_master_root_volume_size: "{{ lookup('env', 'OPENSHIFT_MASTER_ROOT_VOLUME_SIZE')|default(64, true) }}"
+
+openshift_worker_root_volume_size: "{{ lookup('env', 'OPENSHIFT_WORKER_ROOT_VOLUME_SIZE')|default(64, true) }}"
+
+openshift_cidr: "{{ lookup('env', 'OPENSHIFT_CIDR')|default('10.128.0.0/14', true) }}"
+openshift_machine_cidr: "{{ lookup('env', 'OPENSHIFT_MACHINE_CIDR')|default('10.0.0.0/16', true) }}"
+openshift_service_network: "{{ lookup('env', 'OPENSHIFT_SERVICE_NETWORK')|default('172.30.0.0/16', true) }}"
+openshift_host_prefix: "{{ lookup('env', 'OPENSHIFT_HOST_PREFIX')|default(23, true) }}"
+
+# Post-install configuration
+openshift_post_install_poll_attempts: "{{ lookup('env', 'OPENSHIFT_POST_INSTALL_POLL_ATTEMPTS')|default(600, true) }}"
+openshift_toggle_infra_node: "{{ lookup('env', 'OPENSHIFT_TOGGLE_INFRA_NODE')|default(true, true) }}"
+openshift_toggle_workload_node: "{{ lookup('env', 'OPENSHIFT_TOGGLE_WORKLOAD_NODE')|default(true, true) }}"
+# Either machine.openshift.io or sigs.k8s.io
+machineset_metadata_label_prefix: "{{ lookup('env', 'MACHINESET_METADATA_LABEL_PREFIX')|default('machine.openshift.io', true) }}"
+openshift_infra_node_machine_type: "{{ lookup('env', 'OPENSHIFT_INFRA_NODE_MACHINE_TYPE')|default('n1-standard-4', true) }}"
+openshift_workload_node_machine_type: "{{ lookup('env', 'OPENSHIFT_WORKLOAD_NODE_MACHINE_TYPE')|default('n1-standard-4', true) }}"
+
+openshift_infra_node_volume_size: "{{ lookup('env', 'OPENSHIFT_INFRA_NODE_VOLUME_SIZE')|default(64, true) }}"
+openshift_infra_node_volume_type: "{{ lookup('env', 'OPENSHIFT_INFRA_NODE_VOLUME_TYPE')|default('pd-ssd', true) }}"
+
+openshift_workload_node_volume_size: "{{ lookup('env', 'OPENSHIFT_WORKLOAD_NODE_VOLUME_SIZE')|default(64, true) }}"
+openshift_workload_node_volume_type: "{{ lookup('env', 'OPENSHIFT_WORKLOAD_NODE_VOLUME_TYPE')|default('pd-ssd', true) }}"
+
+openshift_prometheus_retention_period: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_RETENTION_PERIOD')|default('15d', true) }}"
+openshift_prometheus_storage_class: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_STORAGE_CLASS')|default('pd-ssd', true) }}"
+openshift_prometheus_storage_size: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_STORAGE_SIZE')|default('10Gi', true) }}"
+openshift_alertmanager_storage_class: "{{ lookup('env', 'OPENSHIFT_ALERTMANAGER_STORAGE_CLASS')|default('pd-ssd', true) }}"
+openshift_alertmanager_storage_size: "{{ lookup('env', 'OPENSHIFT_ALERTMANAGER_STORAGE_SIZE')|default('2Gi', true) }}"
+
+## To specify an alternate auth dir containing kubeconfig, e.g. from GCP cluster installed by Flexy,
+## use only when NOT using the default auth dir located in "${GOPATH}/src/github.com/openshift/installer"
+kubeconfig_auth_dir_path: "{{ lookup('env', 'KUBECONFIG_AUTH_DIR_PATH') }}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ The scale-ci-deploy repo is split into two major directories, playbooks for Open
 | ------------------------ | ----------- | -------- | ------- | ---------------------------- |
 | [AWS](ocp4_aws.md)       | Yes         | Yes      | Yes     | Variable `OPENSHIFT_CLEANUP` |
 | [Azure](ocp4_azure.md)   | Yes         | No       | Yes     | Variable `OPENSHIFT_CLEANUP` |
-| GCP                      | No          | No       | No      | No                           |
+| [GCP](ocp4_gcp.md)       | Yes         | No       | No      | Variable `OPENSHIFT_CLEANUP` |
 | [OpenStack](ocp4_osp.md) | Yes         | No       | Yes     | Separate Playbook            |
 
 ### OpenShift 4 Scale playbook

--- a/docs/ocp4_gcp.md
+++ b/docs/ocp4_gcp.md
@@ -1,0 +1,224 @@
+# OpenShift 4 IPI GCP Install Documentation
+
+The OpenShift 4 IPI GCP install playbook is `OCP-4.X/install-on-gcp.yml` and will deploy a cluster on GCP. In addition to installing a cluster, the playbook can also perform day 2 operations to include deploying three infra nodes and deploying a workload node to isolate workload driver pods from [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
+
+## Usage
+
+Running from the CLI:
+
+```sh
+$ cp OCP-4.X/inventory.example inventory
+$ # Edit inventory and add your expected orchestration host
+$ # Edit deployment variables (Ex vi OCP-4.X/vars/install-on-gcp.yml) or define env variables
+$ ansible-playbook -v -i inventory OCP-4.X/install-on-gcp.yml
+```
+
+## Environment variables
+
+### PUBLIC_KEY
+Default: `~/.ssh/id_rsa.pub`  
+Public ssh key file for Ansible.
+
+### PRIVATE_KEY
+Default: `~/.ssh/id_rsa`  
+Private ssh key file for Ansible.
+
+### ORCHESTRATION_USER
+Default: `root`  
+User for Ansible to log in as. Must authenticate with PUBLIC_KEY/PRIVATE_KEY.
+
+### OPENSHIFT_CLEANUP
+Default: `false`  
+Controls if previously deployed cluster will be destroyed prior to installing a new one.
+
+### OPENSHIFT_INSTALL
+Default: `true`  
+Controls if cluster create and install portion of playbook is ran. The only reason to disable this is if you have a cluster already and wanted to run `OPENSHIFT_POST_INSTALL`, `OPENSHIFT_POST_CONFIG`, and/or `OPENSHIFT_DEBUG_CONFIG` against an existing cluster.
+
+### OPENSHIFT_POST_INSTALL
+Default: `true`  
+Controls if day 2 operations are ran against this cluster. Day 2 operations includes creating infra nodes, creating a workload node, and steering infra workloads to infra nodes.
+
+### OPENSHIFT_POST_CONFIG
+Default: `true`  
+Controls if "post-config" options are ran for this specific cluster. This opens the network security groups for this cluster to permit more network tests to execute from the [openshift-scale/workloads](https://github.com/openshift-scale/workloads) repo.
+
+### OPENSHIFT_DEBUG_CONFIG
+Default: `false`  
+This enables easier debugging for a cluster by populating the initially installed cluster nodes with the kubeconfig and ssh keys for quicker out of band and hands on debugging.
+
+### OPENSHIFT_CLIENT_LOCATION
+Default: No default.  
+Location to download and unpack the OpenShift client tool `oc`. The latest client can be found [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/)
+
+### OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
+Default: No default.  
+The release image override payload. Also where the install `openshift-install` binary is extracted from. Find the latest test images at [https://openshift-release.svc.ci.openshift.org/](https://openshift-release.svc.ci.openshift.org/)
+
+### OPENSHIFT_INSTALL_APIVERSION
+Default: `v1`  
+Depending upon the version of the payload tested this version string might need to be adjusted.
+
+### OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE
+Default: `~/.ssh/id_rsa.pub`  
+Public ssh key file to be used in the install-config.yaml.
+
+### OPENSHIFT_INSTALL_PULL_SECRET
+Default: No default.  
+The pull secret to be used in installing the cluster.
+
+### OPENSHIFT_INSTALL_QUAY_REGISTRY_TOKEN
+Default: No default.  
+The token used to download and extract the installer binary from quay.
+
+### OPENSHIFT_INSTALL_IMAGE_REGISTRY
+Default: `registry.svc.ci.openshift.org`  
+The registry which contains the install image.
+
+### OPENSHIFT_INSTALL_REGISTRY_TOKEN
+Default: No default.  
+The token used to download and extract the installer binary from the registry.
+
+### OPENSHIFT_INSTALL_INSTALLER_FROM_SOURCE
+Default: `false`  
+Option to build the installer binary from source instead of extract method. Not recommended.
+
+### OPENSHIFT_INSTALL_INSTALLER_FROM_SOURCE_VERSION
+Default: `master`  
+Branch to build installer from if `OPENSHIFT_INSTALL_INSTALLER_FROM_SOURCE` is set to true.
+
+### GOPATH
+Default: `/root/.go`  
+When building from source the gopath must be set.
+
+### GCP_SERVICE_ACCOUNT
+Default: No default.  
+The service account is needed for GCP API access. 
+
+### GCP_SERVICE_ACCOUNT_EMAIL
+Default: No default.
+Service account email.
+
+### GCP_AUTH_KEY_FILE
+Default: No default.  
+Path to the GCP auth key file, this is need to authenticate to google cloud.
+
+### GCP_PROJECT
+Default: No default.  
+Project to use.
+
+### GCP_REGION
+Default: No default.  
+The GCP region to install on to. Example: `us-central1`
+
+### OPENSHIFT_BASE_DOMAIN
+Default: No default.  
+The base domain for the cluster.
+
+### OPENSHIFT_CLUSTER_NAME
+Default: No default.  
+The name of the cluster.
+
+### OPENSHIFT_MASTER_COUNT
+Default: `3`  
+The number of master nodes.
+
+### OPENSHIFT_WORKER_COUNT
+Default: `5`  
+The number of worker nodes to install.
+
+### OPENSHIFT_MASTER_VM_SIZE
+Default: `n1-standard-4`  
+The vm size of the masters.
+
+### OPENSHIFT_WORKER_VM_SIZE
+Default: `n1-standard-4`  
+The vm size of the worker nodes.
+
+### OPENSHIFT_MASTER_ROOT_VOLUME_SIZE
+Default: `64`  
+The root volume disk size for the masters.
+
+### OPENSHIFT_WORKER_ROOT_VOLUME_SIZE
+Default: `64`  
+The root volume size for worker nodes.
+
+### OPENSHIFT_CIDR
+Default: `10.128.0.0/14`  
+The block of IP addresses from which Pod IP addresses are allocated.
+
+### OPENSHIFT_MACHINE_CIDR
+Default: `10.0.0.0/16`  
+The block of IP addresses used for hosts.
+
+### OPENSHIFT_SERVICE_NETWORK
+Default: `172.30.0.0/16`  
+The block of IP addresses for services.
+
+### OPENSHIFT_HOST_PREFIX
+Default: `23`  
+The subnet prefix length to assign to each individual node for Pod IP addresses.
+
+### OPENSHIFT_POST_INSTALL_POLL_ATTEMPTS
+Default: `600`  
+The number of times to poll to check while the infra and workload node are being created and added to the cluster.
+
+### OPENSHIFT_TOGGLE_INFRA_NODE
+Default: `true`  
+Enable infra nodes to be created with the `OPENSHIFT_POST_INSTALL` step.
+
+### OPENSHIFT_TOGGLE_WORKLOAD_NODE
+Default: `true`  
+Enable a workload node to be created with the `OPENSHIFT_POST_INSTALL` step.
+
+### MACHINESET_METADATA_LABEL_PREFIX
+Default: `machine.openshift.io`  
+The prefix used in machinesets. Usually this is `machine.openshift.io` however it might be `sigs.k8s.io` depending on version installed.
+
+### OPENSHIFT_INFRA_NODE_VM_SIZE
+Default: `n1-standard-4`  
+The vm size for infra nodes.
+
+### OPENSHIFT_WORKLOAD_NODE_VM_SIZE
+Default: `n1-standard-4`  
+The vm size for the workload node.
+
+### OPENSHIFT_INFRA_NODE_VOLUME_SIZE
+Default: `64`  
+The root volume size for the infra nodes.
+
+### OPENSHIFT_INFRA_NODE_VOLUME_TYPE
+Default: `pd-ssd`  
+The root volume type for infra nodes.
+
+### OPENSHIFT_WORKLOAD_NODE_VOLUME_SIZE
+Default: `64`  
+The root volume size for the workload node.
+
+### OPENSHIFT_WORKLOAD_NODE_VOLUME_TYPE
+Default: `pd-ssd`  
+The root volume type for workload node.
+
+### OPENSHIFT_PROMETHEUS_RETENTION_PERIOD
+Default: `15d`  
+The retention period for the Prometheus server.
+
+### OPENSHIFT_PROMETHEUS_STORAGE_CLASS
+Default: `pd-ssd`  
+The storage class for Prometheus server.
+
+### OPENSHIFT_PROMETHEUS_STORAGE_SIZE
+Default: `10Gi`  
+The storage size for Prometheus server.
+
+### OPENSHIFT_ALERTMANAGER_STORAGE_CLASS
+Default: `pd-ssd`  
+The storage class for the alertmanager servers.
+
+### OPENSHIFT_ALERTMANAGER_STORAGE_SIZE
+Default: `2Gi`  
+The storage size for the alert manager servers.
+
+### KUBECONFIG_AUTH_DIR_PATH
+Default: No default.  
+For use with Flexy built clusters, in which only the post-install steps are ran.


### PR DESCRIPTION
This commit:
- Adds install role to install OCP 4.x on GCP.
- Adds post install roles to create infra, workload nodes and configure
  the cluster to be able to run workloads.
- Adds a readme with the instructions.