### PR TITLE
Copy install log and kubeconfig to store them as artifacts

### DIFF
--- a/OCP-4.X/roles/install-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-aws/tasks/main.yml
@@ -172,3 +172,20 @@
       become: true
     - dest: "{{ansible_user_dir}}/.kube/config"
       become: false
+
+- name: Create dir to store artifacts
+  file:
+    path: "{{ ansible_user_dir }}/scale-ci-aws-artifacts"
+    state: directory
+
+- name: Copy the install log to the artifacts dir
+  fetch:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/.openshift_install.log"
+    dest: "{{ ansible_user_dir }}/scale-ci-aws-artifacts/openshift_install.log"
+    flat: yes
+
+- name: Copy the kubeconfig to the artifacts dir
+  fetch:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/auth/kubeconfig"
+    dest: "{{ ansible_user_dir }}/scale-ci-aws-artifacts/kubeconfig"
+    flat: yes

--- a/OCP-4.X/roles/install-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-azure/tasks/main.yml
@@ -162,3 +162,20 @@
       become: true
     - dest: "{{ansible_user_dir}}/.kube/config"
       become: false
+
+- name: Create dir to store artifacts
+  file:
+    path: "{{ ansible_user_dir }}/scale-ci-azure-artifacts"
+    state: directory
+
+- name: Copy the install log to the artifacts dir
+  fetch:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/.openshift_install.log"
+    dest: "{{ ansible_user_dir }}/scale-ci-azure-artifacts/openshift_install.log"
+    flat: yes
+
+- name: Copy the kubeconfig to the artifacts dir
+  fetch:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/auth/kubeconfig"
+    dest: "{{ ansible_user_dir }}/scale-ci-azure-artifacts/kubeconfig"
+    flat: yes

--- a/OCP-4.X/roles/install-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-gcp/tasks/main.yml
@@ -159,3 +159,20 @@
       become: true
     - dest: "{{ansible_user_dir}}/.kube/config"
       become: false
+
+- name: Create dir to store artifacts
+  file:
+    path: "{{ ansible_user_dir }}/scale-ci-gcp-artifacts"
+    state: directory
+
+- name: Copy the install log to the artifacts dir
+  fetch:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/.openshift_install.log"
+    dest: "{{ ansible_user_dir }}/scale-ci-gcp-artifacts/openshift_install.log"
+    flat: yes
+
+- name: Copy the kubeconfig to the artifacts dir
+  fetch:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/auth/kubeconfig"
+    dest: "{{ ansible_user_dir }}/scale-ci-gcp-artifacts/kubeconfig"
+    flat: yes

--- a/OCP-4.X/roles/install-on-osp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-osp/tasks/main.yml
@@ -212,3 +212,20 @@
       become: true
     - dest: "{{ansible_user_dir}}/.kube/config"
       become: false
+
+- name: Create dir to store artifacts
+  file:
+    path: "{{ ansible_user_dir }}/scale-ci-osp-artifacts"
+    state: directory
+
+- name: Copy the install log to the artifacts dir
+  fetch:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-osp/.openshift_install.log"
+    dest: "{{ ansible_user_dir }}/scale-ci-osp-artifacts/openshift_install.log"
+    flat: yes
+
+- name: Copy the kubeconfig to the artifacts dir
+  fetch:
+    src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-osp/auth/kubeconfig"
+    dest: "{{ ansible_user_dir }}/scale-ci-osp-artifacts/kubeconfig"
+    flat: yes


### PR DESCRIPTION
Copying the files onto the local host will enable us to store them
as artifacts when we run the job from a jenkins slave.