### PR TITLE
Add support to install clusters using binary extracted from url

### DIFF
--- a/OCP-4.X/roles/install-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-aws/tasks/main.yml
@@ -66,7 +66,7 @@
         oc adm release extract --tools {{openshift_install_release_image_override}}
         ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
         chmod +x openshift-install
-  when: not openshift_install_installer_from_source|bool
+  when: not openshift_install_installer_from_source|bool and openshift_install_binary_url == ""
 
 - name: Build installer from source
   block:
@@ -134,6 +134,26 @@
     - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/install-config.yaml"
     - "{{ansible_user_dir}}/scale-ci-deploy/install-config_aws.yaml"
 
+- block:
+   - name: Fetch the openshift-install binary tarball 
+     get_url:
+       url: "{{ openshift_install_binary_url }}"
+       dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/"
+
+   - name: Extract openshift-install binary
+     shell: |
+       set -o pipefail
+       cd {{ansible_user_dir}}/scale-ci-deploy/bin
+       ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
+       chmod +x openshift-install
+
+   - name: Run openshift installer on aws using the provided binary
+     shell: |
+       set -o pipefail
+       cd {{ansible_user_dir}}/scale-ci-deploy
+       bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
+  when: openshift_install_binary_url != ""
+
 - name: run openshift installer on aws using the image override
   shell: |
     set -o pipefail
@@ -141,14 +161,14 @@
     export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
-  when: openshift_install_release_image_override != ""
+  when: openshift_install_release_image_override != "" and openshift_install_binary_url == ""
 
 - name: run openshift installer on aws using the default release image
   shell: |
     set -o pipefail
     cd {{ansible_user_dir}}/scale-ci-deploy
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
-  when: openshift_install_release_image_override == ""
+  when: openshift_install_release_image_override == "" and openshift_install_binary_url == ""
 
 - name: ensure that .kube dir exists
   become: "{{item.become}}"

--- a/OCP-4.X/roles/install-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-azure/tasks/main.yml
@@ -65,7 +65,7 @@
         oc adm release extract --tools {{openshift_install_release_image_override}}
         find -name \*.tar.gz -exec tar -xvf {} \;
         chmod +x openshift-install
-  when: not openshift_install_installer_from_source|bool
+  when: not openshift_install_installer_from_source|bool and openshift_install_build_url == ""
 
 - name: Build installer from source
   block:
@@ -132,6 +132,26 @@
     - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/install-config.yaml"
     - "{{ansible_user_dir}}/scale-ci-deploy/install-config_azure.yaml"
 
+- block:
+   - name: Fetch the openshift-install binary tarball 
+     get_url:
+       url: "{{ openshift_install_build_url }}"
+       dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/"
+
+   - name: Extract openshift-install binary
+     shell: |
+       set -o pipefail
+       cd {{ansible_user_dir}}/scale-ci-deploy/bin
+       ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
+       chmod +x openshift-install
+
+   - name: Run openshift installer on azure using the provided binary
+     shell: |
+       set -o pipefail
+       cd {{ansible_user_dir}}/scale-ci-deploy
+       bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
+  when: openshift_install_build_url != ""
+
 - name: Run openshift-install on Azure using the image override
   shell: |
     set -o pipefail
@@ -139,6 +159,7 @@
     export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
+  when: openshift_install_release_image_override != "" and openshift_install_build_url == ""
 
 - name: Ensure that .kube dir exists
   become: "{{item.become}}"

--- a/OCP-4.X/roles/install-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-gcp/tasks/main.yml
@@ -66,7 +66,7 @@
         oc adm release extract --tools {{openshift_install_release_image_override}}
         find -name \*.tar.gz -exec tar -xvf {} \;
         chmod +x openshift-install
-  when: not openshift_install_installer_from_source|bool
+  when: not openshift_install_installer_from_source|bool and openshift_install_build_url == ""
 
 - name: Build installer from source
   block:
@@ -128,6 +128,25 @@
     - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/install-config.yaml"
     - "{{ansible_user_dir}}/scale-ci-deploy/install-config_gcp.yaml"
 
+- block:
+   - name: Fetch the openshift-install binary tarball 
+     get_url:
+       url: "{{ openshift_install_build_url }}"
+       dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/"
+
+   - name: Extract openshift-install binary
+     shell: |
+       set -o pipefail
+       cd {{ansible_user_dir}}/scale-ci-deploy/bin
+       ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
+       chmod +x openshift-install
+   - name: Run openshift installer on aws using the provided binary
+     shell: |
+       set -o pipefail
+       cd {{ansible_user_dir}}/scale-ci-deploy
+       bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
+  when: openshift_install_build_url != ""
+
 - name: Run openshift-install on GCP using the image override
   shell: |
     set -o pipefail
@@ -136,6 +155,7 @@
     export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     export GOOGLE_CREDENTIALS={{ gcp_auth_key_file }}
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
+  when: openshift_install_release_image_override != "" and openshift_install_build_url == ""
 
 - name: Ensure that .kube dir exists
   become: "{{item.become}}"

--- a/OCP-4.X/roles/install-on-osp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-osp/tasks/main.yml
@@ -46,6 +46,7 @@
     oc adm release extract --tools {{openshift_install_release_image_override}}
     ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
     chmod +x openshift-install
+  when: openshift_install_build_url == ""
 
 - name: Get OpenStack auth url
   shell: |
@@ -181,6 +182,25 @@
     - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-openstack/install-config.yaml"
     - "{{ansible_user_dir}}/scale-ci-deploy/install-config_openstack.yaml"
 
+- block:
+   - name: Fetch the openshift-install binary tarball
+     get_url:
+       url: "{{ openshift_install_build_url }}"
+       dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/"
+
+   - name: Extract openshift-install binary
+     shell: |
+       set -o pipefail
+       cd {{ansible_user_dir}}/scale-ci-deploy/bin
+       ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
+       chmod +x openshift-install
+   - name: Run openshift installer on aws using the provided binary
+     shell: |
+       set -o pipefail
+       cd {{ansible_user_dir}}/scale-ci-deploy
+       bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-openstack/
+  when: openshift_install_build_url != ""
+
 - name: Run openshift-install on OSP using the image override
   shell: |
     set -o pipefail
@@ -189,6 +209,7 @@
     export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     export OS_CLIENT_CONFIG_FILE={{ansible_user_dir}}/scale-ci-deploy/clouds.yml
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-openstack/
+  when: openshift_install_release_image_override != "" and openshift_install_build_url == ""
 
 - name: ensure that .kube dir exists
   become: "{{item.become}}"

--- a/OCP-4.X/vars/install-on-aws.yml
+++ b/OCP-4.X/vars/install-on-aws.yml
@@ -21,6 +21,8 @@ openshift_debug_config: "{{ lookup('env', 'OPENSHIFT_DEBUG_CONFIG')|default(fals
 openshift_client_location: "{{ lookup('env', 'OPENSHIFT_CLIENT_LOCATION') }}"
 # Release payload
 openshift_install_release_image_override: "{{ lookup('env', 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE') }}"
+# Install binary url
+openshift_install_binary_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
 openshift_install_apiversion: "{{ lookup('env', 'OPENSHIFT_INSTALL_APIVERSION')|default('v1', true) }}"
 # ssh key for install-config
 openshift_install_ssh_pub_key_file: "{{ lookup('env', 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"

--- a/OCP-4.X/vars/install-on-azure.yml
+++ b/OCP-4.X/vars/install-on-azure.yml
@@ -21,6 +21,8 @@ openshift_debug_config: "{{ lookup('env', 'OPENSHIFT_DEBUG_CONFIG')|default(fals
 openshift_client_location: "{{ lookup('env', 'OPENSHIFT_CLIENT_LOCATION')}}"
 # Release payload
 openshift_install_release_image_override: "{{ lookup('env', 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE') }}"
+# Install binary url
+openshift_install_binary_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
 openshift_install_apiversion: "{{ lookup('env', 'OPENSHIFT_INSTALL_APIVERSION')|default('v1', true) }}"
 # ssh key for install-config
 openshift_install_ssh_pub_key_file: "{{ lookup('env', 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"

--- a/OCP-4.X/vars/install-on-gcp.yml
+++ b/OCP-4.X/vars/install-on-gcp.yml
@@ -21,6 +21,8 @@ openshift_debug_config: "{{ lookup('env', 'OPENSHIFT_DEBUG_CONFIG')|default(fals
 openshift_client_location: "{{ lookup('env', 'OPENSHIFT_CLIENT_LOCATION') }}"
 # Release payload
 openshift_install_release_image_override: "{{ lookup('env', 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE') }}"
+# Install binary url
+openshift_install_binary_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
 openshift_install_apiversion: "{{ lookup('env', 'OPENSHIFT_INSTALL_APIVERSION')|default('v1', true) }}"
 # ssh key for install-config
 openshift_install_ssh_pub_key_file: "{{ lookup('env', 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"

--- a/OCP-4.X/vars/install-on-osp.yml
+++ b/OCP-4.X/vars/install-on-osp.yml
@@ -27,6 +27,8 @@ openshift_client_location: "{{ lookup('env', 'OPENSHIFT_CLIENT_LOCATION') }}"
 openshift_image_location: "{{ lookup('env', 'OPENSHIFT_IMAGE_LOCATION') }}"
 # Release payload
 openshift_install_release_image_override: "{{ lookup('env', 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE') }}"
+# Install binary url
+openshift_install_binary_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
 openshift_install_apiversion: "{{ lookup('env', 'OPENSHIFT_INSTALL_APIVERSION')|default('v1', true) }}"
 # ssh key for install-config
 openshift_install_ssh_pub_key_file: "{{ lookup('env', 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -61,11 +61,15 @@ This enables easier debugging for a cluster by populating the initially installe
 
 ### OPENSHIFT_CLIENT_LOCATION
 Default: No default.  
-Location to download and unpack the OpenShift client tool `oc`. The latest client can be found [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/)
+Location to download and unpack the OpenShift client tool `oc`. The latest client can be found [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/) or [https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview)
 
 ### OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
 Default: No default.  
 The release image override payload. Also where the install `openshift-install` binary is extracted from. Find the latest test images at [https://openshift-release.svc.ci.openshift.org/](https://openshift-release.svc.ci.openshift.org/)
+
+### OPENSHIFT_INSTALL_BINARY_URL
+Default: No default.
+Link to the binary url tarball to extract the openshift-install from. Find the latest builds at [https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview)
 
 ### OPENSHIFT_INSTALL_APIVERSION
 Default: `v1`  

--- a/docs/ocp4_azure.md
+++ b/docs/ocp4_azure.md
@@ -49,11 +49,15 @@ This enables easier debugging for a cluster by populating the initially installe
 
 ### OPENSHIFT_CLIENT_LOCATION
 Default: No default.  
-Location to download and unpack the OpenShift client tool `oc`. The latest client can be found [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/)
+Location to download and unpack the OpenShift client tool `oc`. The latest client can be found [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/) or [https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview).
 
 ### OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
 Default: No default.  
 The release image override payload. Also where the install `openshift-install` binary is extracted from. Find the latest test images at [https://openshift-release.svc.ci.openshift.org/](https://openshift-release.svc.ci.openshift.org/)
+
+### OPENSHIFT_INSTALL_BINARY_URL
+Default: No default.
+Link to the binary url tarball to extract the openshift-install from. Find the latest builds at [https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview)
 
 ### OPENSHIFT_INSTALL_APIVERSION
 Default: `v1`  

--- a/docs/ocp4_gcp.md
+++ b/docs/ocp4_gcp.md
@@ -49,11 +49,15 @@ This enables easier debugging for a cluster by populating the initially installe
 
 ### OPENSHIFT_CLIENT_LOCATION
 Default: No default.  
-Location to download and unpack the OpenShift client tool `oc`. The latest client can be found [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/)
+Location to download and unpack the OpenShift client tool `oc`. The latest client can be found [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/) or [https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview).
 
 ### OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
 Default: No default.  
 The release image override payload. Also where the install `openshift-install` binary is extracted from. Find the latest test images at [https://openshift-release.svc.ci.openshift.org/](https://openshift-release.svc.ci.openshift.org/)
+
+### OPENSHIFT_INSTALL_BINARY_URL
+Default: No default.
+Link to the binary url tarball to extract the openshift-install from. Find the latest builds at [https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview)
 
 ### OPENSHIFT_INSTALL_APIVERSION
 Default: `v1`  

--- a/docs/ocp4_osp.md
+++ b/docs/ocp4_osp.md
@@ -57,7 +57,7 @@ Determines if the image will be uploaded into Glance on the OpenStack Cloud. If 
 
 ### OPENSHIFT_CLIENT_LOCATION
 Default: No default.  
-Location to download and unpack the OpenShift client tool `oc`. The latest client can be found [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/)
+Location to download and unpack the OpenShift client tool `oc`. The latest client can be found [https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/) or [https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview).
 
 ### OPENSHIFT_IMAGE_LOCATION
 Default: No default.  
@@ -66,6 +66,10 @@ Location to download the latest RHCOS image. The image is expected in qcow2 form
 ### OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE
 Default: No default.  
 The release image override payload. Also where the install `openshift-install` binary is extracted from. Find the latest test images at [https://openshift-release.svc.ci.openshift.org/](https://openshift-release.svc.ci.openshift.org/)
+
+### OPENSHIFT_INSTALL_BINARY_URL
+Default: No default.
+Link to the binary url tarball to extract the openshift-install from. Find the latest builds at [https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview](https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview)
 
 ### OPENSHIFT_INSTALL_APIVERSION
 Default: `v1`  


### PR DESCRIPTION
This commits enables us to use the openshift-install binary extracted
from a provided url in addition to extracting it from the provided
image.

Fixes https://github.com/openshift-scale/scale-ci-deploy/issues/40