### PR TITLE
Deploy OVN from scale-ci-deploy

### DIFF
--- a/OCP-4.X/roles/install-on-aws/templates/install-config.yaml.j2
+++ b/OCP-4.X/roles/install-on-aws/templates/install-config.yaml.j2
@@ -28,7 +28,7 @@ networking:
   - cidr: {{ openshift_cidr }}
     hostPrefix: {{ openshift_host_prefix }}
   machineCIDR: {{ openshift_machine_cidr }}
-  networkType: OpenshiftSDN
+  networkType: {{openshift_network_type}}
   serviceNetwork:
   - {{ openshift_service_network }}
 platform:

--- a/OCP-4.X/roles/install-on-azure/templates/install-config.yaml.j2
+++ b/OCP-4.X/roles/install-on-azure/templates/install-config.yaml.j2
@@ -26,7 +26,7 @@ networking:
   - cidr: {{ openshift_cidr }}
     hostPrefix: {{ openshift_host_prefix }}
   machineCIDR: {{ openshift_machine_cidr }}
-  networkType: OpenShiftSDN
+  networkType: {{openshift_network_type}}
   serviceNetwork:
   - {{ openshift_service_network }}
 platform:

--- a/OCP-4.X/roles/install-on-gcp/templates/install-config.yaml.j2
+++ b/OCP-4.X/roles/install-on-gcp/templates/install-config.yaml.j2
@@ -22,7 +22,7 @@ networking:
   - cidr: {{ openshift_cidr }}
     hostPrefix: {{ openshift_host_prefix }}
   machineCIDR: {{ openshift_machine_cidr }}
-  networkType: OpenShiftSDN
+  networkType: {{openshift_network_type}}
   serviceNetwork:
   - {{ openshift_service_network }}
 platform:

--- a/OCP-4.X/vars/install-on-aws.yml
+++ b/OCP-4.X/vars/install-on-aws.yml
@@ -64,6 +64,7 @@ openshift_cidr: "{{ lookup('env', 'OPENSHIFT_CIDR')|default('10.128.0.0/14', tru
 openshift_machine_cidr: "{{ lookup('env', 'OPENSHIFT_MACHINE_CIDR')|default('10.0.0.0/16', true) }}"
 openshift_service_network: "{{ lookup('env', 'OPENSHIFT_SERVICE_NETWORK')|default('172.30.0.0/16', true) }}"
 openshift_host_prefix: "{{ lookup('env', 'OPENSHIFT_HOST_PREFIX')|default(23, true) }}"
+openshift_network_type: "{{ lookup('env', 'OPENSHIFT_NETWORK_TYPE')|default('OpenShiftSDN', true) }}"
 
 # Post-install configuration
 openshift_post_install_poll_attempts: "{{ lookup('env', 'OPENSHIFT_POST_INSTALL_POLL_ATTEMPTS')|default(600, true) }}"

--- a/OCP-4.X/vars/install-on-azure.yml
+++ b/OCP-4.X/vars/install-on-azure.yml
@@ -62,6 +62,7 @@ openshift_cidr: "{{ lookup('env', 'OPENSHIFT_CIDR')|default('10.128.0.0/14', tru
 openshift_machine_cidr: "{{ lookup('env', 'OPENSHIFT_MACHINE_CIDR')|default('10.0.0.0/16', true) }}"
 openshift_service_network: "{{ lookup('env', 'OPENSHIFT_SERVICE_NETWORK')|default('172.30.0.0/16', true) }}"
 openshift_host_prefix: "{{ lookup('env', 'OPENSHIFT_HOST_PREFIX')|default(23, true) }}"
+openshift_network_type: "{{ lookup('env', 'OPENSHIFT_NETWORK_TYPE')|default('OpenShiftSDN', true) }}"
 
 # Post-install configuration
 openshift_post_install_poll_attempts: "{{ lookup('env', 'OPENSHIFT_POST_INSTALL_POLL_ATTEMPTS')|default(600, true) }}"

--- a/OCP-4.X/vars/install-on-gcp.yml
+++ b/OCP-4.X/vars/install-on-gcp.yml
@@ -61,6 +61,7 @@ openshift_cidr: "{{ lookup('env', 'OPENSHIFT_CIDR')|default('10.128.0.0/14', tru
 openshift_machine_cidr: "{{ lookup('env', 'OPENSHIFT_MACHINE_CIDR')|default('10.0.0.0/16', true) }}"
 openshift_service_network: "{{ lookup('env', 'OPENSHIFT_SERVICE_NETWORK')|default('172.30.0.0/16', true) }}"
 openshift_host_prefix: "{{ lookup('env', 'OPENSHIFT_HOST_PREFIX')|default(23, true) }}"
+openshift_network_type: "{{ lookup('env', 'OPENSHIFT_NETWORK_TYPE')|default('OpenShiftSDN', true) }}"
 
 # Post-install configuration
 openshift_post_install_poll_attempts: "{{ lookup('env', 'OPENSHIFT_POST_INSTALL_POLL_ATTEMPTS')|default(600, true) }}"

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -187,6 +187,10 @@ The block of IP addresses for services.
 Default: `23`  
 The subnet prefix length to assign to each individual node for Pod IP addresses.
 
+### OPENSHIFT_NETWORK_TYPE
+Default: `OpenShiftSDN`
+The network type used for the cluster, for OVN set it to `OVNKubernetes`. 
+
 ### OPENSHIFT_POST_INSTALL_POLL_ATTEMPTS
 Default: `600`  
 The number of times to poll to check while the infra and workload node are being created and added to the cluster.

--- a/docs/ocp4_azure.md
+++ b/docs/ocp4_azure.md
@@ -167,6 +167,10 @@ The block of IP addresses for services.
 Default: `23`  
 The subnet prefix length to assign to each individual node for Pod IP addresses.
 
+### OPENSHIFT_NETWORK_TYPE
+Default: `OpenShiftSDN`
+The network type used for the cluster, for OVN set it to `OVNKubernetes`.
+
 ### OPENSHIFT_POST_INSTALL_POLL_ATTEMPTS
 Default: `600`  
 The number of times to poll to check while the infra and workload node are being created and added to the cluster.

--- a/docs/ocp4_gcp.md
+++ b/docs/ocp4_gcp.md
@@ -163,6 +163,10 @@ The block of IP addresses for services.
 Default: `23`  
 The subnet prefix length to assign to each individual node for Pod IP addresses.
 
+### OPENSHIFT_NETWORK_TYPE
+Default: `OpenShiftSDN`
+The network type used for the cluster, for OVN set it to `OVNKubernetes`.
+
 ### OPENSHIFT_POST_INSTALL_POLL_ATTEMPTS
 Default: `600`  
 The number of times to poll to check while the infra and workload node are being created and added to the cluster.


### PR DESCRIPTION
This will give us the ability to toggle between OVS and OVN for cluster deployment. @jtaleric @chaitanyaenr 