### PR TITLE
Allow configuring network type in install-config.yaml

### DIFF
--- a/OCP-4.X/roles/install-on-aws/templates/install-config.yaml.j2
+++ b/OCP-4.X/roles/install-on-aws/templates/install-config.yaml.j2
@@ -28,7 +28,7 @@ networking:
   - cidr: {{ openshift_cidr }}
     hostPrefix: {{ openshift_host_prefix }}
   machineCIDR: {{ openshift_machine_cidr }}
-  networkType: OpenshiftSDN
+  networkType: {{ openshift_network_type | default(OpenshiftSDN) }}
   serviceNetwork:
   - {{ openshift_service_network }}
 platform:

--- a/OCP-4.X/roles/install-on-azure/templates/install-config.yaml.j2
+++ b/OCP-4.X/roles/install-on-azure/templates/install-config.yaml.j2
@@ -26,7 +26,7 @@ networking:
   - cidr: {{ openshift_cidr }}
     hostPrefix: {{ openshift_host_prefix }}
   machineCIDR: {{ openshift_machine_cidr }}
-  networkType: OpenShiftSDN
+  networkType: {{ openshift_network_type | default(OpenshiftSDN) }}
   serviceNetwork:
   - {{ openshift_service_network }}
 platform:

--- a/OCP-4.X/roles/install-on-gcp/templates/install-config.yaml.j2
+++ b/OCP-4.X/roles/install-on-gcp/templates/install-config.yaml.j2
@@ -22,7 +22,7 @@ networking:
   - cidr: {{ openshift_cidr }}
     hostPrefix: {{ openshift_host_prefix }}
   machineCIDR: {{ openshift_machine_cidr }}
-  networkType: OpenShiftSDN
+  networkType: {{ openshift_network_type | default(OpenshiftSDN) }}
   serviceNetwork:
   - {{ openshift_service_network }}
 platform:

--- a/OCP-4.X/roles/install-on-osp/templates/install-config.yaml.j2
+++ b/OCP-4.X/roles/install-on-osp/templates/install-config.yaml.j2
@@ -24,7 +24,7 @@ networking:
     # hostSubnetLength: 9
   # serviceCIDR: 172.30.0.0/16
   machineCIDR: {{openshift_machine_cidr}}
-  networkType: {{openshift_network_type}}
+  networkType: {{ openshift_network_type | default(OpenshiftSDN) }}
   serviceNetwork:
   - {{openshift_service_network}}
 platform:


### PR DESCRIPTION
This PR will allow configure SDN plugin. The current behavior remains intact as it defaults to OpenShiftSDN