### PR TITLE
Make vars consistent with the task

### DIFF
--- a/OCP-4.X/roles/install-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-aws/tasks/main.yml
@@ -66,7 +66,7 @@
         oc adm release extract --tools {{openshift_install_release_image_override}}
         ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
         chmod +x openshift-install
-  when: not openshift_install_installer_from_source|bool and openshift_install_binary_url == ""
+  when: not openshift_install_installer_from_source|bool and openshift_install_build_url == ""
 
 - name: Build installer from source
   block:
@@ -137,7 +137,7 @@
 - block:
    - name: Fetch the openshift-install binary tarball 
      get_url:
-       url: "{{ openshift_install_binary_url }}"
+       url: "{{ openshift_install_build_url }}"
        dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/"
 
    - name: Extract openshift-install binary
@@ -152,7 +152,7 @@
        set -o pipefail
        cd {{ansible_user_dir}}/scale-ci-deploy
        bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
-  when: openshift_install_binary_url != ""
+  when: openshift_install_build_url != ""
 
 - name: run openshift installer on aws using the image override
   shell: |
@@ -161,14 +161,14 @@
     export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
-  when: openshift_install_release_image_override != "" and openshift_install_binary_url == ""
+  when: openshift_install_release_image_override != "" and openshift_install_build_url == ""
 
 - name: run openshift installer on aws using the default release image
   shell: |
     set -o pipefail
     cd {{ansible_user_dir}}/scale-ci-deploy
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
-  when: openshift_install_release_image_override == "" and openshift_install_binary_url == ""
+  when: openshift_install_release_image_override == "" and openshift_install_build_url == ""
 
 - name: ensure that .kube dir exists
   become: "{{item.become}}"

--- a/OCP-4.X/vars/install-on-aws.yml
+++ b/OCP-4.X/vars/install-on-aws.yml
@@ -22,7 +22,7 @@ openshift_client_location: "{{ lookup('env', 'OPENSHIFT_CLIENT_LOCATION') }}"
 # Release payload
 openshift_install_release_image_override: "{{ lookup('env', 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE') }}"
 # Install binary url
-openshift_install_binary_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
+openshift_install_build_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
 openshift_install_apiversion: "{{ lookup('env', 'OPENSHIFT_INSTALL_APIVERSION')|default('v1', true) }}"
 # ssh key for install-config
 openshift_install_ssh_pub_key_file: "{{ lookup('env', 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"

--- a/OCP-4.X/vars/install-on-azure.yml
+++ b/OCP-4.X/vars/install-on-azure.yml
@@ -22,7 +22,7 @@ openshift_client_location: "{{ lookup('env', 'OPENSHIFT_CLIENT_LOCATION')}}"
 # Release payload
 openshift_install_release_image_override: "{{ lookup('env', 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE') }}"
 # Install binary url
-openshift_install_binary_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
+openshift_install_build_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
 openshift_install_apiversion: "{{ lookup('env', 'OPENSHIFT_INSTALL_APIVERSION')|default('v1', true) }}"
 # ssh key for install-config
 openshift_install_ssh_pub_key_file: "{{ lookup('env', 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"

--- a/OCP-4.X/vars/install-on-gcp.yml
+++ b/OCP-4.X/vars/install-on-gcp.yml
@@ -22,7 +22,7 @@ openshift_client_location: "{{ lookup('env', 'OPENSHIFT_CLIENT_LOCATION') }}"
 # Release payload
 openshift_install_release_image_override: "{{ lookup('env', 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE') }}"
 # Install binary url
-openshift_install_binary_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
+openshift_install_build_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
 openshift_install_apiversion: "{{ lookup('env', 'OPENSHIFT_INSTALL_APIVERSION')|default('v1', true) }}"
 # ssh key for install-config
 openshift_install_ssh_pub_key_file: "{{ lookup('env', 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"

--- a/OCP-4.X/vars/install-on-osp.yml
+++ b/OCP-4.X/vars/install-on-osp.yml
@@ -28,7 +28,7 @@ openshift_image_location: "{{ lookup('env', 'OPENSHIFT_IMAGE_LOCATION') }}"
 # Release payload
 openshift_install_release_image_override: "{{ lookup('env', 'OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE') }}"
 # Install binary url
-openshift_install_binary_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
+openshift_install_build_url: "{{ lookup('env', 'OPENSHIFT_INSTALL_BINARY_URL') }}"
 openshift_install_apiversion: "{{ lookup('env', 'OPENSHIFT_INSTALL_APIVERSION')|default('v1', true) }}"
 # ssh key for install-config
 openshift_install_ssh_pub_key_file: "{{ lookup('env', 'OPENSHIFT_INSTALL_SSH_PUB_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"


### PR DESCRIPTION
Variables will be consistent across all the cloud/osp deployments.
To provide the binary, use env var of `OPENSHIFT_INSTALL_BINARY_URL`
@chaitanyaenr 