### PR TITLE
make vars consistent with tasks

### DIFF
--- a/OCP-4.X/roles/install-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-azure/tasks/main.yml
@@ -65,7 +65,7 @@
         oc adm release extract --tools {{openshift_install_release_image_override}}
         find -name \*.tar.gz -exec tar -xvf {} \;
         chmod +x openshift-install
-  when: not openshift_install_installer_from_source|bool and openshift_install_build_url == ""
+  when: not openshift_install_installer_from_source|bool and openshift_install_binary_url == ""
 
 - name: Build installer from source
   block:
@@ -135,7 +135,7 @@
 - block:
    - name: Fetch the openshift-install binary tarball 
      get_url:
-       url: "{{ openshift_install_build_url }}"
+       url: "{{ openshift_install_binary_url }}"
        dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/"
 
    - name: Extract openshift-install binary
@@ -150,7 +150,7 @@
        set -o pipefail
        cd {{ansible_user_dir}}/scale-ci-deploy
        bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
-  when: openshift_install_build_url != ""
+  when: openshift_install_binary_url != ""
 
 - name: Run openshift-install on Azure using the image override
   shell: |
@@ -159,7 +159,7 @@
     export OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
-  when: openshift_install_release_image_override != "" and openshift_install_build_url == ""
+  when: openshift_install_release_image_override != "" and openshift_install_binary_url == ""
 
 - name: Ensure that .kube dir exists
   become: "{{item.become}}"

--- a/OCP-4.X/roles/install-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-gcp/tasks/main.yml
@@ -66,7 +66,7 @@
         oc adm release extract --tools {{openshift_install_release_image_override}}
         find -name \*.tar.gz -exec tar -xvf {} \;
         chmod +x openshift-install
-  when: not openshift_install_installer_from_source|bool and openshift_install_build_url == ""
+  when: not openshift_install_installer_from_source|bool and openshift_install_binary_url == ""
 
 - name: Build installer from source
   block:
@@ -131,7 +131,7 @@
 - block:
    - name: Fetch the openshift-install binary tarball 
      get_url:
-       url: "{{ openshift_install_build_url }}"
+       url: "{{ openshift_install_binary_url }}"
        dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/"
 
    - name: Extract openshift-install binary
@@ -145,7 +145,7 @@
        set -o pipefail
        cd {{ansible_user_dir}}/scale-ci-deploy
        bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
-  when: openshift_install_build_url != ""
+  when: openshift_install_binary_url != ""
 
 - name: Run openshift-install on GCP using the image override
   shell: |
@@ -155,7 +155,7 @@
     export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     export GOOGLE_CREDENTIALS={{ gcp_auth_key_file }}
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
-  when: openshift_install_release_image_override != "" and openshift_install_build_url == ""
+  when: openshift_install_release_image_override != "" and openshift_install_binary_url == ""
 
 - name: Ensure that .kube dir exists
   become: "{{item.become}}"

--- a/OCP-4.X/roles/install-on-osp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-osp/tasks/main.yml
@@ -46,7 +46,7 @@
     oc adm release extract --tools {{openshift_install_release_image_override}}
     ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
     chmod +x openshift-install
-  when: openshift_install_build_url == ""
+  when: openshift_install_binary_url == ""
 
 - name: Get OpenStack auth url
   shell: |
@@ -185,7 +185,7 @@
 - block:
    - name: Fetch the openshift-install binary tarball
      get_url:
-       url: "{{ openshift_install_build_url }}"
+       url: "{{ openshift_install_binary_url }}"
        dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/"
 
    - name: Extract openshift-install binary
@@ -199,7 +199,7 @@
        set -o pipefail
        cd {{ansible_user_dir}}/scale-ci-deploy
        bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-openstack/
-  when: openshift_install_build_url != ""
+  when: openshift_install_binary_url != ""
 
 - name: Run openshift-install on OSP using the image override
   shell: |
@@ -209,7 +209,7 @@
     export _OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE={{ openshift_install_release_image_override }}
     export OS_CLIENT_CONFIG_FILE={{ansible_user_dir}}/scale-ci-deploy/clouds.yml
     bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-openstack/
-  when: openshift_install_release_image_override != "" and openshift_install_build_url == ""
+  when: openshift_install_release_image_override != "" and openshift_install_binary_url == ""
 
 - name: ensure that .kube dir exists
   become: "{{item.become}}"


### PR DESCRIPTION
Variables will be consistent across all the cloud/osp deployments.  
To provide the binary, use env var of OPENSHIFT_INSTALL_BINARY_URL 
@chaitanyaenr 