### PR TITLE
Use playbook_dir instead of ansible_user_dir

### DIFF
--- a/OCP-4.X/roles/install-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-aws/tasks/main.yml
@@ -195,17 +195,18 @@
 
 - name: Create dir to store artifacts
   file:
-    path: "{{ ansible_user_dir }}/scale-ci-aws-artifacts"
+    path: "{{ playbook_dir }}/scale-ci-aws-artifacts"
     state: directory
+  delegate_to: localhost
 
 - name: Copy the install log to the artifacts dir
   fetch:
     src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/.openshift_install.log"
-    dest: "{{ ansible_user_dir }}/scale-ci-aws-artifacts/openshift_install.log"
+    dest: "{{ playbook_dir }}/scale-ci-aws-artifacts/openshift_install.log"
     flat: yes
 
 - name: Copy the kubeconfig to the artifacts dir
   fetch:
     src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/auth/kubeconfig"
-    dest: "{{ ansible_user_dir }}/scale-ci-aws-artifacts/kubeconfig"
+    dest: "{{ playbook_dir }}/scale-ci-aws-artifacts/kubeconfig"
     flat: yes

--- a/OCP-4.X/roles/install-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-azure/tasks/main.yml
@@ -186,17 +186,18 @@
 
 - name: Create dir to store artifacts
   file:
-    path: "{{ ansible_user_dir }}/scale-ci-azure-artifacts"
+    path: "{{ playbook_dir }}/scale-ci-azure-artifacts"
     state: directory
+  delegate_to: localhost
 
 - name: Copy the install log to the artifacts dir
   fetch:
     src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/.openshift_install.log"
-    dest: "{{ ansible_user_dir }}/scale-ci-azure-artifacts/openshift_install.log"
+    dest: "{{ playbook_dir }}/scale-ci-azure-artifacts/openshift_install.log"
     flat: yes
 
 - name: Copy the kubeconfig to the artifacts dir
   fetch:
     src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/auth/kubeconfig"
-    dest: "{{ ansible_user_dir }}/scale-ci-azure-artifacts/kubeconfig"
+    dest: "{{ playbook_dir }}/scale-ci-azure-artifacts/kubeconfig"
     flat: yes

--- a/OCP-4.X/roles/install-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-gcp/tasks/main.yml
@@ -182,17 +182,18 @@
 
 - name: Create dir to store artifacts
   file:
-    path: "{{ ansible_user_dir }}/scale-ci-gcp-artifacts"
+    path: "{{ playbook_dir }}/scale-ci-gcp-artifacts"
     state: directory
+  delegate_to: localhost
 
 - name: Copy the install log to the artifacts dir
   fetch:
     src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/.openshift_install.log"
-    dest: "{{ ansible_user_dir }}/scale-ci-gcp-artifacts/openshift_install.log"
+    dest: "{{ playbook_dir }}/scale-ci-gcp-artifacts/openshift_install.log"
     flat: yes
 
 - name: Copy the kubeconfig to the artifacts dir
   fetch:
     src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/auth/kubeconfig"
-    dest: "{{ ansible_user_dir }}/scale-ci-gcp-artifacts/kubeconfig"
+    dest: "{{ playbook_dir }}/scale-ci-gcp-artifacts/kubeconfig"
     flat: yes

--- a/OCP-4.X/roles/install-on-osp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-osp/tasks/main.yml
@@ -238,15 +238,16 @@
   file:
     path: "{{ ansible_user_dir }}/scale-ci-osp-artifacts"
     state: directory
+  delegate_to: localhost
 
 - name: Copy the install log to the artifacts dir
   fetch:
     src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-osp/.openshift_install.log"
-    dest: "{{ ansible_user_dir }}/scale-ci-osp-artifacts/openshift_install.log"
+    dest: "{{ playbook_dir }}/scale-ci-osp-artifacts/openshift_install.log"
     flat: yes
 
 - name: Copy the kubeconfig to the artifacts dir
   fetch:
     src: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-osp/auth/kubeconfig"
-    dest: "{{ ansible_user_dir }}/scale-ci-osp-artifacts/kubeconfig"
+    dest: "{{ playbook_dir }}/scale-ci-osp-artifacts/kubeconfig"
     flat: yes


### PR DESCRIPTION
This will keep the host clean by storing the artifacts in the playbook dir
instead of users home directory.