### PR TITLE
Cluster monitoring operator changes for OCP 4.3

### DIFF
--- a/OCP-4.X/roles/post-install/files/version-patch-override.yaml
+++ b/OCP-4.X/roles/post-install/files/version-patch-override.yaml
@@ -1,0 +1,8 @@
+- op: add
+  path: /spec/overrides
+  value:
+  - kind: Deployment
+    group: apps/v1
+    name: cluster-monitoring-operator
+    namespace: openshift-monitoring
+    unmanaged: true

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -168,6 +168,21 @@
   ignore_errors: yes
   when: openshift_toggle_infra_node|bool
 
+- block:
+   - name: Add override for cluster-monitoring-operator to disable CVO management
+     copy:
+       src: version-patch-override.yaml
+       dest: "/tmp/version-patch-override.yaml"
+  
+   - name: Patch the clusteversion with the overrides
+     shell: |
+       oc patch clusterversion version --type json -p "$(cat /tmp/version-patch-override.yaml)"
+
+   - name: Remove the existing node selector from the cluster-monitoring-operator deployment config
+     shell: |
+       oc patch deployment.apps/cluster-monitoring-operator -n openshift-monitoring --type json -p '[{"op": "remove", "path": "/spec/template/spec/nodeSelector"}]'
+  when: openshift_toggle_infra_node|bool
+
 # Attempting to migrate these operators seems to break upgrades
 # - name: Remove existing nodeSelector from ingress-operator
 #   shell: |
@@ -196,7 +211,7 @@
       patch: |
         '{"spec": {"nodePlacement": {"nodeSelector": {"matchLabels": {"node-role.kubernetes.io/infra": ""}}}}}'
       type: "--type merge"
-        # Monitoring (Relocate from worker nodes) - Does not require CVO Disable
+    # Monitoring (Relocate from worker nodes) - Does not require CVO Disable
     - namespace: openshift-monitoring
       object: deployment.apps/cluster-monitoring-operator
       patch: |
@@ -206,6 +221,7 @@
       #   object: deployment.apps/cluster-image-registry-operator
       #   patch: |
       #     '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/infra": ""}}}}}'
+
     - namespace: openshift-image-registry
       object: deployment.apps/image-registry
       patch: |

--- a/OCP-4.X/vars/install-on-azure.yml
+++ b/OCP-4.X/vars/install-on-azure.yml
@@ -86,9 +86,9 @@ openshift_workload_node_volume_size: "{{ lookup('env', 'OPENSHIFT_WORKLOAD_NODE_
 openshift_workload_node_volume_type: "{{ lookup('env', 'OPENSHIFT_WORKLOAD_NODE_VOLUME_TYPE')|default('Premium_LRS', true) }}"
 
 openshift_prometheus_retention_period: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_RETENTION_PERIOD')|default('15d', true) }}"
-openshift_prometheus_storage_class: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_STORAGE_CLASS')|default('Premium_LRS', true) }}"
+openshift_prometheus_storage_class: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_STORAGE_CLASS')|default('managed-premium', true) }}"
 openshift_prometheus_storage_size: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_STORAGE_SIZE')|default('10Gi', true) }}"
-openshift_alertmanager_storage_class: "{{ lookup('env', 'OPENSHIFT_ALERTMANAGER_STORAGE_CLASS')|default('Premium_LRS', true) }}"
+openshift_alertmanager_storage_class: "{{ lookup('env', 'OPENSHIFT_ALERTMANAGER_STORAGE_CLASS')|default('managed-premium', true) }}"
 openshift_alertmanager_storage_size: "{{ lookup('env', 'OPENSHIFT_ALERTMANAGER_STORAGE_SIZE')|default('2Gi', true) }}"
 
 ## To specify an alternate auth dir containing kubeconfig, e.g. from Azure cluster installed by Flexy,

--- a/docs/ocp4_azure.md
+++ b/docs/ocp4_azure.md
@@ -228,7 +228,7 @@ Default: `15d`
 The retention period for the Prometheus server.
 
 ### OPENSHIFT_PROMETHEUS_STORAGE_CLASS
-Default: `Premium_LRS`  
+Default: `managed-premium`  
 The storage class for Prometheus server.
 
 ### OPENSHIFT_PROMETHEUS_STORAGE_SIZE
@@ -236,7 +236,7 @@ Default: `10Gi`
 The storage size for Prometheus server.
 
 ### OPENSHIFT_ALERTMANAGER_STORAGE_CLASS
-Default: `Premium_LRS`  
+Default: `managed-premium`  
 The storage class for the alertmanager servers.
 
 ### OPENSHIFT_ALERTMANAGER_STORAGE_SIZE


### PR DESCRIPTION
This commit:
- Adds support to disable cluster-monitoring-operator
from being controlled by cvo to be able to run the monitoring
components on dedicated infra nodes.
- Changes the default storage class to managed_premium as that's the
default storage class avaiable for OCP 4.3 installs.