### PR TITLE
Avoid steering cluster-monitoring-operator onto infra nodes

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -168,20 +168,21 @@
   ignore_errors: yes
   when: openshift_toggle_infra_node|bool
 
-- block:
-   - name: Add override for cluster-monitoring-operator to disable CVO management
-     copy:
-       src: version-patch-override.yaml
-       dest: "/tmp/version-patch-override.yaml"
+# Need this to steer cluster-monitoring-operator onto the infra nodes
+#- block:
+#   - name: Add override for cluster-monitoring-operator to disable CVO management
+#     copy:
+#       src: version-patch-override.yaml
+#       dest: "/tmp/version-patch-override.yaml"
 
-   - name: Patch the clusteversion with the overrides
-     shell: |
-       oc patch clusterversion version --type json -p "$(cat /tmp/version-patch-override.yaml)"
+#   - name: Patch the clusteversion with the overrides
+#     shell: |
+#       oc patch clusterversion version --type json -p "$(cat /tmp/version-patch-override.yaml)"
 
-   - name: Remove the existing node selector from the cluster-monitoring-operator deployment config
-     shell: |
-       oc patch deployment.apps/cluster-monitoring-operator -n openshift-monitoring --type json -p '[{"op": "remove", "path": "/spec/template/spec/nodeSelector"}]'
-  when: openshift_toggle_infra_node|bool
+#   - name: Remove the existing node selector from the cluster-monitoring-operator deployment config
+#     shell: |
+#       oc patch deployment.apps/cluster-monitoring-operator -n openshift-monitoring --type json -p '[{"op": "remove", "path": "/spec/template/spec/nodeSelector"}]'
+#  when: openshift_toggle_infra_node|bool
 
 # Attempting to migrate these operators seems to break upgrades
 # - name: Remove existing nodeSelector from ingress-operator
@@ -211,11 +212,11 @@
       patch: |
         '{"spec": {"nodePlacement": {"nodeSelector": {"matchLabels": {"node-role.kubernetes.io/infra": ""}}}}}'
       type: "--type merge"
-    # Monitoring (Relocate from worker nodes) - Does not require CVO Disable
-    - namespace: openshift-monitoring
-      object: deployment.apps/cluster-monitoring-operator
-      patch: |
-        '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/infra": ""}}}}}'
+    # Monitoring (Relocate cluster-monitoring-operator from worker nodes) - Requires CVO overriding
+    #- namespace: openshift-monitoring
+    #  object: deployment.apps/cluster-monitoring-operator
+    #  patch: |
+    #    '{"spec": {"template": {"spec": {"nodeSelector": {"node-role.kubernetes.io/infra": ""}}}}}'
       # Registry (Relocate from master nodes) - Does not require CVO Disable
       # - namespace: openshift-image-registry
       #   object: deployment.apps/cluster-image-registry-operator


### PR DESCRIPTION
Steering the cluster-monitoring-operator needs overriding CVO which
leads to upgrade failures, so we just steer the monitoring components
including prometheus, alertmanager, grafana and kube-state metrics by
modifying the cluster-monitoring-config ConfigMap.