### PR TITLE
Fixed item.dest in OCP-4.X role node-debug-config in task Copy the kubeconfig to node from specific directory

### DIFF
--- a/OCP-4.X/roles/node-debug-config/tasks/main.yml
+++ b/OCP-4.X/roles/node-debug-config/tasks/main.yml
@@ -32,7 +32,7 @@
   become: "{{item.become}}"
   copy:
     src: "{{ kubeconfig_auth_dir_path }}/auth/kubeconfig"
-    dest: "{{ item }}"
+    dest: "{{ item.dest }}"
   with_items:
     - dest: /home/core/.kube/config
       become: false


### PR DESCRIPTION
the ".dest" part was missing causing python errors when executed.