### PR TITLE
Add support to capture OCP build info

### DIFF
--- a/OCP-4.X/build-info.yml
+++ b/OCP-4.X/build-info.yml
@@ -1,0 +1,67 @@
+---
+- hosts: orchestration
+  remote_user: "{{ orchestration_user }}"
+  vars_files:
+    - vars/build-info.yml
+  tasks:
+    - name: Fetch the build info content from the provided location
+      uri:
+        url: "{{ build_info_url }}"
+        method: GET
+        return_content: yes
+        body_format: json
+      register: build_info
+
+    - name: Dump the captured build info to a file
+      copy:
+        content: "{{ (build_info.content|from_json) }}"
+        dest: "{{ build_info_destination }}/build_info.json"
+
+    - name: Filter and capture the payload to a file
+      copy:
+        content: "{{ (build_info.content|from_json).msg.pullSpec }}"
+        dest: "{{ build_info_destination }}/payload"
+
+    - name: Check if the file with the info about the previous payload exists
+      stat:
+        path: "{{ build_info_destination }}/payload.previous"
+      register: previous_payload_file
+    
+    - block:
+        - name: Capture the previous payload
+          slurp:
+            src: "{{ build_info_destination }}/payload.previous"
+          register: previous_payload
+
+        - name: Capture the current payload
+          slurp:
+            src: "{{ build_info_destination }}/payload"
+          register: current_payload
+
+        - name: Compare the current payload captured from the UMB with previous payload and update the status file with PROCEED signal when they don't match
+          copy:
+            content: "PROCEED"
+            dest: "{{ build_info_destination }}/build.status"
+            force: yes
+          when: previous_payload.content| b64decode| trim != current_payload.content| b64decode| trim
+
+        - name: Compare the current payload captured from the UMB with previous payload and update the status with STOP signal when they match
+          copy:
+            content: "STOP"
+            dest: "{{ build_info_destination }}/build.status"
+            force: yes
+          when: previous_payload.content| b64decode| trim == current_payload.content| b64decode| trim
+      when: previous_payload_file.stat.exists == True
+
+    - block:
+        - name: Update the build status file with Proceed signal when info about previous payload doesn't exist
+          copy:
+            content: "PROCEED"
+            dest: "{{ build_info_destination }}/build.status"
+            force: yes
+
+        - name: Populate the previous payload info
+          copy:
+            content: "{{ (build_info.content|from_json).msg.pullSpec }}"
+            dest: "{{ build_info_destination }}/payload.previous"
+      when: previous_payload_file.stat.exists == False

--- a/OCP-4.X/vars/build-info.yml
+++ b/OCP-4.X/vars/build-info.yml
@@ -1,0 +1,17 @@
+---
+###############################################################################
+# Ansible SSH variables.
+###############################################################################
+ansible_public_key_file: "{{ lookup('env', 'PUBLIC_KEY')|default('~/.ssh/id_rsa.pub', true) }}"
+ansible_private_key_file: "{{ lookup('env', 'PRIVATE_KEY')|default('~/.ssh/id_rsa', true) }}"
+
+orchestration_user: "{{ lookup('env', 'ORCHESTRATION_USER')|default('root', true) }}"
+###############################################################################
+# Build info vars
+###############################################################################
+# Url to query for the build info
+build_info_url: "{{ lookup('env', 'BUILD_INFO_URL') }}"
+
+# Destination to dump the captured build info content.
+# The playbook captures the build info at <build_info_destination>/build_info.json and payload to use at <build_info_destination>/payload.
+build_info_destination: "{{ lookup('env', 'BUILD_INFO_DESTINATION')|default('/tmp', true) }}"


### PR DESCRIPTION
This commit:
- Adds a playbook which queries for the build info from the provided
  info and dumps it to a specified destination. The use case for adding
  this is to query the umb message for the OCP green nighltly builds
  and update the file in a location accessible over http. This captured
  content can be used to trigger OCP installs on a nightly basis.
- This also adds/updates a status file with PROCEED/STOP signal which can
  be used by the OCP install jobs to decide whether to proceed with the build
  or not. The status file is updated with the PROCEED if there's a mismatch
  between the payloads or when we don't have info about the previous payload
  and it's updated with STOP signal if the previous and current payload captured
  from the UMB message are the same. We can use this logic in the later stages to
  update the status file in case the install/test fails during which we want to keep
  the environment to debug instead of deleting it.