### PR TITLE
Check the cluster status before attempting destroy

### DIFF
--- a/OCP-4.X/roles/cleanup-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-aws/tasks/main.yml
@@ -3,16 +3,23 @@
 # Clean up AWS install
 #
 
-- name: Cleanup AWS cluster
-  shell: |
-    cd {{ansible_user_dir}}/scale-ci-deploy
-    bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
+- name: Check if a cluster is running
+  stat:
+    path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/metadata.json"
+  register: cluster_status
 
-- name: Clean scale-ci-deploy openshift-install directories
-  become: true
-  file:
-    path: "{{item}}"
-    state: absent
-  with_items:
-    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
-    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws"
+- block:
+    - name: Cleanup AWS cluster
+      shell: |
+        cd {{ansible_user_dir}}/scale-ci-deploy
+        bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
+
+    - name: Clean scale-ci-deploy openshift-install directories
+      become: true
+      file:
+        path: "{{item}}"
+        state: absent
+      with_items:
+        - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+        - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws"
+  when: cluster_status.stat.exists == True

--- a/OCP-4.X/roles/cleanup-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-azure/tasks/main.yml
@@ -3,16 +3,23 @@
 # Clean up Azure IPI install
 #
 
-- name: Cleanup Azure cluster
-  shell: |
-    cd {{ansible_user_dir}}/scale-ci-deploy
-    bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
+- name: Check if a cluster is running
+  stat:
+    path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/metadata.json"
+  register: cluster_status
 
-- name: Clean scale-ci-deploy openshift-install directories
-  become: true
-  file:
-    path: "{{item}}"
-    state: absent
-  with_items:
-    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
-    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure"
+- block:
+    - name: Cleanup Azure cluster
+      shell: |
+        cd {{ansible_user_dir}}/scale-ci-deploy
+        bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
+
+    - name: Clean scale-ci-deploy openshift-install directories
+      become: true
+      file:
+        path: "{{item}}"
+        state: absent
+      with_items:
+        - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+        - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure"
+  when: cluster_status.stat.exists == True

--- a/OCP-4.X/roles/cleanup-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-gcp/tasks/main.yml
@@ -3,17 +3,24 @@
 # Clean up GCP  IPI install
 #
 
+- name: Check if a cluster is running
+  stat:
+    path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/metadata.json"
+  register: cluster_status
+
 - name: Cleanup GCP cluster
   shell: |
     cd {{ansible_user_dir}}/scale-ci-deploy
     export GOOGLE_CREDENTIALS={{ gcp_auth_key_file }}
     bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
 
-- name: Clean scale-ci-deploy openshift-install directories
-  become: true
-  file:
-    path: "{{item}}"
-    state: absent
-  with_items:
-    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
-    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp"
+- block:
+    - name: Clean scale-ci-deploy openshift-install directories
+      become: true
+      file:
+        path: "{{item}}"
+        state: absent
+      with_items:
+        - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+        - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp"
+  when: cluster_status.stat.exists == True


### PR DESCRIPTION
This commit enables us always enable cleanup irrespective of whether
a cluster is running or not. It checks if a cluster is running and
runs the destroy operation only when it exists.

Fixes https://github.com/openshift-scale/scale-ci-deploy/issues/59