### PR TITLE
Added cluster_name.stdout prefix to machineset name

### DIFF
--- a/OCP-4.X/roles/post-install/templates/aws-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/aws-workload-node-machineset.yml.j2
@@ -8,7 +8,7 @@ items:
       {{machineset_metadata_label_prefix}}/cluster-api-cluster: {{cluster_name.stdout}}
       {{machineset_metadata_label_prefix}}/cluster-api-machine-role: workload
       {{machineset_metadata_label_prefix}}/cluster-api-machine-type: workload
-    name: workload-{{aws_region.stdout}}a
+    name: {{cluster_name.stdout}}-workload-{{aws_region.stdout}}a
     namespace: openshift-machine-api
   spec:
     replicas: 1


### PR DESCRIPTION
The cluster_name was needed to be part of the machineset name in order for destroy cluster functionality to succeed, otherwise workload node was not deleted and our automated jobs to destroy clusters were failing.