### PR TITLE
Added support to enable cerberus

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -281,3 +281,38 @@
       args:
         chdir: "{{ansible_user_dir}}/dittybopper"
   when: dittybopper_enable
+
+- name: Enable cerberus
+  block:
+    - name: Generate cerberus config file
+      template:
+        src: cerberus.j2
+        dest: "{{ cerberus_config_path }}"
+
+    - name: Install podman
+      yum:
+        name: podman
+        state: latest
+
+    - name: Pull "{{ cerberus_image }}" image
+      podman_image:
+        name: "{{ cerberus_image }}"
+        force: yes
+
+    - name: Check if cerberus is running
+      shell: podman ps | grep -w cerberus || podman ps -a | grep -w cerberus
+      register: cerberus_status
+      ignore_errors: yes
+
+    - name: Delete cerberus container if it exists
+      shell: podman rm -f cerberus
+      when: cerberus_status.rc == 0
+
+    - name: Run containerized version of "{{ cerberus_image }}"
+      command: podman run --name=cerberus --net=host -v "{{ kubeconfig_path }}":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z -d "{{ cerberus_image }}"
+      when: not slack_integration
+
+    - name: Run containerized version of "{{ cerberus_image }}" with slack integration
+      command: podman run --name=cerberus --net=host -v "{{ kubeconfig_path }}":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z --env SLACK_API_TOKEN="{{ slack_api_token }}" --env SLACK_CHANNEL="{{ slack_channel }}" -d "{{ cerberus_image }}"
+      when: slack_integration 
+  when: cerberus_enable

--- a/OCP-4.X/roles/post-install/templates/cerberus.j2
+++ b/OCP-4.X/roles/post-install/templates/cerberus.j2
@@ -1,0 +1,16 @@
+cerberus:
+    kubeconfig_path: {{ kubeconfig_path }}                  # Path to kubeconfig
+    watch_nodes: {{ watch_nodes }}                          # Set to True for the cerberus to monitor the cluster nodes
+    watch_namespaces: {{ watch_namespaces }}                # List of namespaces to be monitored
+    cerberus_publish_status: {{ cerberus_publish_status }}  # When enabled, cerberus starts a light weight http server and publishes the status
+    inspect_components: {{ inspect_components }}            # Enable it only when OpenShift client is supported to run
+                                                            # When enabled, cerberus collects logs, events and metrics of failed components
+    slack_integration: {{ slack_integration }}              # When enabled, cerberus reports the failed iterations in the slack channel
+                                                            # When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in the slack channel. Values are slack member ID's.
+    cop_slack_ID: {{ cop_slack_ID }}                        # (NOTE: Defining the cop id's is optional and when the cop slack id's are not defined, the slack_team_alias tag is used if it is set else no tag is used while reporting failures in the slack channel.)
+    slack_team_alias: {{ slack_team_alias }}                # The slack team alias to be tagged while reporting failures in the slack channel when no cop is assigned
+
+tunings:
+    iterations: {{ iterations }}                            # Iterations to loop before stopping the watch, it will be replaced with infinity when the daemon mode is enabled
+    sleep_time: {{ sleep_time }}                            # Sleep duration between each iteration
+    daemon_mode: {{ daemon_mode }}                          # Iterations are set to infinity which means that the cerberus will monitor the resources forever

--- a/OCP-4.X/vars/install-on-aws.yml
+++ b/OCP-4.X/vars/install-on-aws.yml
@@ -72,7 +72,31 @@ openshift_toggle_infra_node: "{{ lookup('env', 'OPENSHIFT_TOGGLE_INFRA_NODE')|de
 openshift_toggle_workload_node: "{{ lookup('env', 'OPENSHIFT_TOGGLE_WORKLOAD_NODE')|default(true, true) }}"
 
 ## Mutable Grafana
-dittybopper_enable : "{{ lookup('env', 'ENABLE_DITTYBOPPER')|default(true, true) }}"
+dittybopper_enable: "{{ lookup('env', 'ENABLE_DITTYBOPPER')|default(true, true) }}"
+
+# kube config and cerberus config locations
+kubeconfig_path: "{{ lookup('env', 'KUBECONFIG_PATH')|default('~/.kube/config', true) }}"
+cerberus_config_path: "{{ lookup('env', 'CERBERUS_CONFIG_PATH')|default('~/cerberus.yaml', true) }}"
+
+# Cerberus image
+cerberus_image: "{{ lookup('env', 'CERBERUS_IMAGE')|default('quay.io/openshift-scale/cerberus:latest', true) }}"
+
+# Cerberus configurations
+watch_nodes: "{{ lookup('env', 'WATCH_NODES')|default(true, true) }}"
+watch_namespaces: "{{ lookup('env', 'WATCH_NAMESPACES')|default('[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn, openshift-ovn-kubernetes]', true) }}"
+cerberus_publish_status: "{{ lookup('env', 'CERBERUS_PUBLISH_STATUS')|default(true, true) }}"
+inspect_components: "{{ lookup('env', 'INSPECT_COMPONENTS')|default(false, true) }}"
+slack_integration: "{{ lookup('env', 'SLACK_INTEGRATION')|default(false, true) }}"
+slack_api_token: "{{ lookup('env', 'SLACK_API_TOKEN') }}"
+slack_channel: "{{ lookup('env', 'SLACK_CHANNEL') }}"
+cop_slack_ID: "{{ lookup('env', 'COP_SLACK_ID')|default('{Monday: , Tuesday: , Wednesday: , Thursday: , Friday: , Saturday: , Sunday: }', true) }}"
+slack_team_alias: "{{ lookup('env', 'SLACK_TEAM_ALIAS') }}"
+iterations: "{{ lookup('env', 'ITERATIONS')|default(5, true) }}"
+sleep_time: "{{ lookup('env', 'SLEEP_TIME')|default(60, true) }}"
+daemon_mode: "{{ lookup('env', 'DAEMON_MODE')|default(true, true) }}"
+
+# Cereberus enable
+cerberus_enable : "{{ lookup('env', 'CERBERUS_ENABLE')|default(false, true) }}"
 
 ## Remote write details
 sincgars_enable: "{{ lookup('env', 'ENABLE_REMOTE_WRITE')|default(false, true) }}"

--- a/OCP-4.X/vars/install-on-azure.yml
+++ b/OCP-4.X/vars/install-on-azure.yml
@@ -70,7 +70,31 @@ openshift_toggle_infra_node: "{{ lookup('env', 'OPENSHIFT_TOGGLE_INFRA_NODE')|de
 openshift_toggle_workload_node: "{{ lookup('env', 'OPENSHIFT_TOGGLE_WORKLOAD_NODE')|default(true, true) }}"
 
 ## Mutable Grafana
-dittybopper_enable : "{{ lookup('env', 'ENABLE_DITTYBOPPER')|default(true, true) }}"
+dittybopper_enable: "{{ lookup('env', 'ENABLE_DITTYBOPPER')|default(true, true) }}"
+
+# kube config and cerberus config locations
+kubeconfig_path: "{{ lookup('env', 'KUBECONFIG_PATH')|default('~/.kube/config', true) }}"
+cerberus_config_path: "{{ lookup('env', 'CERBERUS_CONFIG_PATH')|default('~/cerberus.yaml', true) }}"
+
+# Cerberus image
+cerberus_image: "{{ lookup('env', 'CERBERUS_IMAGE')|default('quay.io/openshift-scale/cerberus:latest', true) }}"
+
+# Cerberus configurations
+watch_nodes: "{{ lookup('env', 'WATCH_NODES')|default(true, true) }}"
+watch_namespaces: "{{ lookup('env', 'WATCH_NAMESPACES')|default('[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn, openshift-ovn-kubernetes]', true) }}"
+cerberus_publish_status: "{{ lookup('env', 'CERBERUS_PUBLISH_STATUS')|default(true, true) }}"
+inspect_components: "{{ lookup('env', 'INSPECT_COMPONENTS')|default(false, true) }}"
+slack_integration: "{{ lookup('env', 'SLACK_INTEGRATION')|default(false, true) }}"
+slack_api_token: "{{ lookup('env', 'SLACK_API_TOKEN') }}"
+slack_channel: "{{ lookup('env', 'SLACK_CHANNEL') }}"
+cop_slack_ID: "{{ lookup('env', 'COP_SLACK_ID')|default('{Monday: , Tuesday: , Wednesday: , Thursday: , Friday: , Saturday: , Sunday: }', true) }}"
+slack_team_alias: "{{ lookup('env', 'SLACK_TEAM_ALIAS') }}"
+iterations: "{{ lookup('env', 'ITERATIONS')|default(5, true) }}"
+sleep_time: "{{ lookup('env', 'SLEEP_TIME')|default(60, true) }}"
+daemon_mode: "{{ lookup('env', 'DAEMON_MODE')|default(true, true) }}"
+
+# Cereberus enable
+cerberus_enable : "{{ lookup('env', 'CERBERUS_ENABLE')|default(false, true) }}"
 
 ## Remote write details
 sincgars_enable: "{{ lookup('env', 'ENABLE_REMOTE_WRITE')|default(false, true) }}"

--- a/OCP-4.X/vars/install-on-gcp.yml
+++ b/OCP-4.X/vars/install-on-gcp.yml
@@ -66,7 +66,31 @@ openshift_network_type: "{{ lookup('env', 'OPENSHIFT_NETWORK_TYPE')|default('Ope
 # Post-install configuration
 
 ## Mutable Grafana
-dittybopper_enable : "{{ lookup('env', 'ENABLE_DITTYBOPPER')|default(true, true) }}"
+dittybopper_enable: "{{ lookup('env', 'ENABLE_DITTYBOPPER')|default(true, true) }}"
+
+# kube config and cerberus config locations
+kubeconfig_path: "{{ lookup('env', 'KUBECONFIG_PATH')|default('~/.kube/config', true) }}"
+cerberus_config_path: "{{ lookup('env', 'CERBERUS_CONFIG_PATH')|default('~/cerberus.yaml', true) }}"
+
+# Cerberus image
+cerberus_image: "{{ lookup('env', 'CERBERUS_IMAGE')|default('quay.io/openshift-scale/cerberus:latest', true) }}"
+
+# Cerberus configurations
+watch_nodes: "{{ lookup('env', 'WATCH_NODES')|default(true, true) }}"
+watch_namespaces: "{{ lookup('env', 'WATCH_NAMESPACES')|default('[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn, openshift-ovn-kubernetes]', true) }}"
+cerberus_publish_status: "{{ lookup('env', 'CERBERUS_PUBLISH_STATUS')|default(true, true) }}"
+inspect_components: "{{ lookup('env', 'INSPECT_COMPONENTS')|default(false, true) }}"
+slack_integration: "{{ lookup('env', 'SLACK_INTEGRATION')|default(false, true) }}"
+slack_api_token: "{{ lookup('env', 'SLACK_API_TOKEN') }}"
+slack_channel: "{{ lookup('env', 'SLACK_CHANNEL') }}"
+cop_slack_ID: "{{ lookup('env', 'COP_SLACK_ID')|default('{Monday: , Tuesday: , Wednesday: , Thursday: , Friday: , Saturday: , Sunday: }', true) }}"
+slack_team_alias: "{{ lookup('env', 'SLACK_TEAM_ALIAS') }}"
+iterations: "{{ lookup('env', 'ITERATIONS')|default(5, true) }}"
+sleep_time: "{{ lookup('env', 'SLEEP_TIME')|default(60, true) }}"
+daemon_mode: "{{ lookup('env', 'DAEMON_MODE')|default(true, true) }}"
+
+# Cereberus enable
+cerberus_enable : "{{ lookup('env', 'CERBERUS_ENABLE')|default(false, true) }}"
 
 ## Remote write details
 sincgars_enable: "{{ lookup('env', 'ENABLE_REMOTE_WRITE')|default(false, true) }}"

--- a/OCP-4.X/vars/install-on-osp.yml
+++ b/OCP-4.X/vars/install-on-osp.yml
@@ -57,7 +57,31 @@ openshift_host_prefix: "{{ lookup('env', 'OPENSHIFT_HOST_PREFIX')|default(23, tr
 # Post-install configuration
 
 ## Mutable Grafana
-dittybopper_enable : "{{ lookup('env', 'ENABLE_DITTYBOPPER')|default(true, true) }}"
+dittybopper_enable: "{{ lookup('env', 'ENABLE_DITTYBOPPER')|default(true, true) }}"
+
+# kube config and cerberus config locations
+kubeconfig_path: "{{ lookup('env', 'KUBECONFIG_PATH')|default('~/.kube/config', true) }}"
+cerberus_config_path: "{{ lookup('env', 'CERBERUS_CONFIG_PATH')|default('~/cerberus.yaml', true) }}"
+
+# Cerberus image
+cerberus_image: "{{ lookup('env', 'CERBERUS_IMAGE')|default('quay.io/openshift-scale/cerberus:latest', true) }}"
+
+# Cerberus configurations
+watch_nodes: "{{ lookup('env', 'WATCH_NODES')|default(true, true) }}"
+watch_namespaces: "{{ lookup('env', 'WATCH_NAMESPACES')|default('[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn, openshift-ovn-kubernetes]', true) }}"
+cerberus_publish_status: "{{ lookup('env', 'CERBERUS_PUBLISH_STATUS')|default(true, true) }}"
+inspect_components: "{{ lookup('env', 'INSPECT_COMPONENTS')|default(false, true) }}"
+slack_integration: "{{ lookup('env', 'SLACK_INTEGRATION')|default(false, true) }}"
+slack_api_token: "{{ lookup('env', 'SLACK_API_TOKEN') }}"
+slack_channel: "{{ lookup('env', 'SLACK_CHANNEL') }}"
+cop_slack_ID: "{{ lookup('env', 'COP_SLACK_ID')|default('{Monday: , Tuesday: , Wednesday: , Thursday: , Friday: , Saturday: , Sunday: }', true) }}"
+slack_team_alias: "{{ lookup('env', 'SLACK_TEAM_ALIAS') }}"
+iterations: "{{ lookup('env', 'ITERATIONS')|default(5, true) }}"
+sleep_time: "{{ lookup('env', 'SLEEP_TIME')|default(60, true) }}"
+daemon_mode: "{{ lookup('env', 'DAEMON_MODE')|default(true, true) }}"
+
+# Cereberus enable
+cerberus_enable : "{{ lookup('env', 'CERBERUS_ENABLE')|default(false, true) }}"
 
 ## Remote write details
 sincgars_enable: "{{ lookup('env', 'ENABLE_REMOTE_WRITE')|default(false, true) }}"

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -219,6 +219,70 @@ Enable infra nodes to be created with the `OPENSHIFT_POST_INSTALL` step.
 Default: `true`
 Enable a workload node to be created with the `OPENSHIFT_POST_INSTALL` step.
 
+### KUBECONFIG_PATH
+Default: `~/.kube/config`
+Path to kube_config.
+
+### CERBERUS_CONFIG_PATH
+Default: `~/cerberus.yaml`
+Path to cerberus_config.
+
+### CERBERUS IMAGE
+Default: `quay.io/openshift-scale/cerberus:latest`
+Image to be pulled to run the containerized version of cerberus.
+
+### WATCH NODES
+Default: `true`
+Set to True for the cerberus to monitor the cluster nodes.
+
+### WATCH NAMESPACES
+Default: `'[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn, openshift-ovn-kubernetes]'`
+List the namespaces to be monitored by cerberus.
+
+### CERBERUS_PUBLISH_STATUS
+Default: `true`
+When enabled, cerberus starts a light weight http server and publishes the status.
+
+### INSPECT_COMPONENTS
+Default: `false`
+Enable it only when OpenShift client is supported to run. When enabled, cerberus collects logs, events and metrics of failed components.
+
+### SLACK_INTEGRATION
+Default: `false`
+When enabled, cerberus reports the the failed interations and sends the report for the same on a slack channel.
+
+### SLACK_API_TOKEN
+Default: No default.
+It refers to Bot User OAuth Access Token used for cerberus.
+
+### SLACK_CHANNEL
+Default: No default.
+It refers to the slack channel ID the user wishes to receive the notifications for cerberus failures.
+
+### COP_SLACK_ID
+Default: `'{Monday: , Tuesday: , Wednesday: , Thursday: , Friday: , Saturday: , Sunday: }'`
+When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
+
+### SLACK_TEAM_ALIAS
+Default: No default.
+The slack team alias to be tagged while reporting failures in the slack channel when no cop is assigned.
+
+### ITERATIONS
+Default: `5`
+Iterations to loop before stopping the watch in cerberus monitoring. It will be replaced with infinity when the daemon mode is enabled.
+
+### SLEEP_TIME
+Default: `60`
+Sleep duration between each iteration in cerberus monitoring.
+
+### DAEMON_MODE
+Default: `true`
+Iterations are set to infinity which means that the cerberus will monitor the resources forever.
+
+### CERBERUS_ENABLE
+Default: `false`
+Controls whether the monitoring of Kubernetes/OpenShift cluster components by cerberus should be enabled or not.
+
 ### MACHINESET_METADATA_LABEL_PREFIX
 Default: `machine.openshift.io`
 The prefix used in machinesets. Usually this is `machine.openshift.io` however it might be `sigs.k8s.io` depending on version installed.

--- a/docs/ocp4_azure.md
+++ b/docs/ocp4_azure.md
@@ -199,6 +199,70 @@ Enable infra nodes to be created with the `OPENSHIFT_POST_INSTALL` step.
 Default: `true`
 Enable a workload node to be created with the `OPENSHIFT_POST_INSTALL` step.
 
+### KUBE_CONFIG
+Default: `~/.kube/config`
+Path to kube_config.
+
+### CERBERUS_CONFIG
+Default: `~/cerberus.yaml`
+Path to cerberus_config.
+
+### CERBERUS IMAGE
+Default: `quay.io/openshift-scale/cerberus:latest`
+Image to be pulled to run the containerized version of cerberus.
+
+### WATCH NODES
+Default: `true`
+Set to True for the cerberus to monitor the cluster nodes.
+
+### WATCH NAMESPACES
+Default: `'[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn, openshift-ovn-kubernetes]'`
+List the namespaces to be monitored by cerberus.
+
+### CERBERUS_PUBLISH_STATUS
+Default: `true`
+When enabled, cerberus starts a light weight http server and publishes the status.
+
+### INSPECT_COMPONENTS
+Default: `false`
+Enable it only when OpenShift client is supported to run. When enabled, cerberus collects logs, events and metrics of failed components.
+
+### SLACK_INTEGRATION
+Default: `false`
+When enabled, cerberus reports the the failed interations and sends the report for the same on a slack channel.
+
+### SLACK_API_TOKEN
+Default: No default.
+It refers to Bot User OAuth Access Token used for cerberus.
+
+### SLACK_CHANNEL
+Default: No default.
+It refers to the slack channel ID the user wishes to receive the notifications for cerberus failures.
+
+### COP_SLACK_ID
+Default: `'{Monday: , Tuesday: , Wednesday: , Thursday: , Friday: , Saturday: , Sunday: }'`
+When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
+
+### SLACK_TEAM_ALIAS
+Default: No default.
+The slack team alias to be tagged while reporting failures in the slack channel when no cop is assigned.
+
+### ITERATIONS
+Default: `5`
+Iterations to loop before stopping the watch in cerberus monitoring. It will be replaced with infinity when the daemon mode is enabled.
+
+### SLEEP_TIME
+Default: `60`
+Sleep duration between each iteration in cerberus monitoring.
+
+### DAEMON_MODE
+Default: `true`
+Iterations are set to infinity which means that the cerberus will monitor the resources forever.
+
+### CERBERUS_ENABLE
+Default: `false`
+Controls whether the monitoring of Kubernetes/OpenShift cluster components by cerberus should be enabled or not.
+
 ### MACHINESET_METADATA_LABEL_PREFIX
 Default: `machine.openshift.io`
 The prefix used in machinesets. Usually this is `machine.openshift.io` however it might be `sigs.k8s.io` depending on version installed.

--- a/docs/ocp4_gcp.md
+++ b/docs/ocp4_gcp.md
@@ -195,6 +195,70 @@ Enable infra nodes to be created with the `OPENSHIFT_POST_INSTALL` step.
 Default: `true`
 Enable a workload node to be created with the `OPENSHIFT_POST_INSTALL` step.
 
+### KUBE_CONFIG
+Default: `~/.kube/config`
+Path to kube_config.
+
+### CERBERUS_CONFIG
+Default: `~/cerberus.yaml`
+Path to cerberus_config.
+
+### CERBERUS IMAGE
+Default: `quay.io/openshift-scale/cerberus:latest`
+Image to be pulled to run the containerized version of cerberus.
+
+### WATCH NODES
+Default: `true`
+Set to True for the cerberus to monitor the cluster nodes.
+
+### WATCH NAMESPACES
+Default: `'[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn, openshift-ovn-kubernetes]'`
+List the namespaces to be monitored by cerberus.
+
+### CERBERUS_PUBLISH_STATUS
+Default: `true`
+When enabled, cerberus starts a light weight http server and publishes the status.
+
+### INSPECT_COMPONENTS
+Default: `false`
+Enable it only when OpenShift client is supported to run. When enabled, cerberus collects logs, events and metrics of failed components.
+
+### SLACK_INTEGRATION
+Default: `false`
+When enabled, cerberus reports the the failed interations and sends the report for the same on a slack channel.
+
+### SLACK_API_TOKEN
+Default: No default.
+It refers to Bot User OAuth Access Token used for cerberus.
+
+### SLACK_CHANNEL
+Default: No default.
+It refers to the slack channel ID the user wishes to receive the notifications for cerberus failures.
+
+### COP_SLACK_ID
+Default: `'{Monday: , Tuesday: , Wednesday: , Thursday: , Friday: , Saturday: , Sunday: }'`
+When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
+
+### SLACK_TEAM_ALIAS
+Default: No default.
+The slack team alias to be tagged while reporting failures in the slack channel when no cop is assigned.
+
+### ITERATIONS
+Default: `5`
+Iterations to loop before stopping the watch in cerberus monitoring. It will be replaced with infinity when the daemon mode is enabled.
+
+### SLEEP_TIME
+Default: `60`
+Sleep duration between each iteration in cerberus monitoring.
+
+### DAEMON_MODE
+Default: `true`
+Iterations are set to infinity which means that the cerberus will monitor the resources forever.
+
+### CERBERUS_ENABLE
+Default: `false`
+Controls whether the monitoring of Kubernetes/OpenShift cluster components by cerberus should be enabled or not.
+
 ### MACHINESET_METADATA_LABEL_PREFIX
 Default: `machine.openshift.io`
 The prefix used in machinesets. Usually this is `machine.openshift.io` however it might be `sigs.k8s.io` depending on version installed.

--- a/docs/ocp4_osp.md
+++ b/docs/ocp4_osp.md
@@ -167,6 +167,70 @@ Enable infra nodes to be created with the `OPENSHIFT_POST_INSTALL` step.
 Default: `true`
 Enable a workload node to be created with the `OPENSHIFT_POST_INSTALL` step.
 
+### KUBE_CONFIG
+Default: `~/.kube/config`
+Path to kube_config.
+
+### CERBERUS_CONFIG
+Default: `~/cerberus.yaml`
+Path to cerberus_config.
+
+### CERBERUS IMAGE
+Default: `quay.io/openshift-scale/cerberus:latest`
+Image to be pulled to run the containerized version of cerberus.
+
+### WATCH NODES
+Default: `true`
+Set to True for the cerberus to monitor the cluster nodes.
+
+### WATCH NAMESPACES
+Default: `'[openshift-etcd, openshift-apiserver, openshift-kube-apiserver, openshift-monitoring, openshift-kube-controller, openshift-machine-api, openshift-kube-scheduler, openshift-ingress, openshift-sdn, openshift-ovn-kubernetes]'`
+List the namespaces to be monitored by cerberus.
+
+### CERBERUS_PUBLISH_STATUS
+Default: `true`
+When enabled, cerberus starts a light weight http server and publishes the status.
+
+### INSPECT_COMPONENTS
+Default: `false`
+Enable it only when OpenShift client is supported to run. When enabled, cerberus collects logs, events and metrics of failed components.
+
+### SLACK_INTEGRATION
+Default: `false`
+When enabled, cerberus reports the the failed interations and sends the report for the same on a slack channel.
+
+### SLACK_API_TOKEN
+Default: No default.
+It refers to Bot User OAuth Access Token used for cerberus.
+
+### SLACK_CHANNEL
+Default: No default.
+It refers to the slack channel ID the user wishes to receive the notifications for cerberus failures.
+
+### COP_SLACK_ID
+Default: `'{Monday: , Tuesday: , Wednesday: , Thursday: , Friday: , Saturday: , Sunday: }'`
+When slack_integration is enabled, a cop can be assigned for each day. The cop of the day is tagged while reporting failures in a slack channel. Values are slack member ID's.
+
+### SLACK_TEAM_ALIAS
+Default: No default.
+The slack team alias to be tagged while reporting failures in the slack channel when no cop is assigned.
+
+### ITERATIONS
+Default: `5`
+Iterations to loop before stopping the watch in cerberus monitoring. It will be replaced with infinity when the daemon mode is enabled.
+
+### SLEEP_TIME
+Default: `60`
+Sleep duration between each iteration in cerberus monitoring.
+
+### DAEMON_MODE
+Default: `true`
+Iterations are set to infinity which means that the cerberus will monitor the resources forever.
+
+### CERBERUS_ENABLE
+Default: `false`
+Controls whether the monitoring of Kubernetes/OpenShift cluster components by cerberus should be enabled or not.
+
 ### MACHINESET_METADATA_LABEL_PREFIX
 Default: `machine.openshift.io`
 The prefix used in machinesets. Usually this is `machine.openshift.io` however it might be `sigs.k8s.io` depending on version installed.


### PR DESCRIPTION
This commit is a first step towards #64 
This commit enables the containerized version of cerberus to be
installed and enabled after the OCP installation.

This commit is based on `https://github.com/openshift-scale/cerberus/pull/38` 