### PR TITLE
Adding Cerberus integration

### DIFF
--- a/OCP-4.X/install-on-aws.yml
+++ b/OCP-4.X/install-on-aws.yml
@@ -18,8 +18,12 @@
       when: openshift_install|bool
     - role: post-install
       when: openshift_post_install|bool
+    - role: cerberus_install
+      when: cerberus_enable|bool
     - role: post-config-on-aws
       when: openshift_post_config|bool
+    - role: cerberus
+      when: cerberus_enable|bool
 
 - name: (Optional) Debugging configuration of workload node
   hosts: workload

--- a/OCP-4.X/install-on-azure.yml
+++ b/OCP-4.X/install-on-azure.yml
@@ -18,8 +18,12 @@
       when: openshift_install|bool
     - role: post-install
       when: openshift_post_install|bool
+    - role: cerberus_install
+      when: cerberus_enable|bool
     - role: post-config-on-azure
       when: openshift_post_config|bool
+    - role: cerberus
+      when: cerberus_enable|bool
 
 - name: (Optional) Debugging configuration of workload node
   hosts: workload

--- a/OCP-4.X/install-on-gcp.yml
+++ b/OCP-4.X/install-on-gcp.yml
@@ -18,8 +18,12 @@
       when: openshift_install|bool
     - role: post-install
       when: openshift_post_install|bool
+    - role: cerberus_install
+      when: cerberus_enable|bool
     - role: post-config-on-gcp
       when: openshift_post_config|bool
+    - role: cerberus
+      when: cerberus_enable|bool
 
 - name: (Optional) Debugging configuration of workload node
   hosts: workload

--- a/OCP-4.X/install-on-osp.yml
+++ b/OCP-4.X/install-on-osp.yml
@@ -16,8 +16,12 @@
       when: openshift_install|bool
     - role: post-install
       when: openshift_post_install|bool
+    - role: cerberus_install
+      when: cerberus_enable|bool
     - role: post-config-on-osp
       when: openshift_post_config|bool
+    - role: cerberus
+      when: cerberus_enable|bool
 
 - name: (Optional) Debugging configuration of workload node
   hosts: workload

--- a/OCP-4.X/roles/cerberus/tasks/main.yml
+++ b/OCP-4.X/roles/cerberus/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Get status from Cerberus
+  uri:
+    url: "{{ cerberus_url }}"
+    return_content: yes
+  register: result
+  failed_when: "'True' not in result.content"

--- a/OCP-4.X/roles/cerberus_install/tasks/main.yml
+++ b/OCP-4.X/roles/cerberus_install/tasks/main.yml
@@ -1,0 +1,32 @@
+---
+- name: Generate cerberus config file
+  template:
+    src: cerberus.j2
+    dest: "{{ cerberus_config_path }}"
+
+- name: Install podman
+  yum:
+    name: podman
+    state: latest
+
+- name: Pull "{{ cerberus_image }}" image
+  podman_image:
+    name: "{{ cerberus_image }}"
+    force: yes
+
+- name: Check if cerberus is running
+  shell: podman ps | grep -w cerberus || podman ps -a | grep -w cerberus
+  register: cerberus_status
+  ignore_errors: yes
+
+- name: Delete cerberus container if it exists
+  shell: podman rm -f cerberus
+  when: cerberus_status.rc == 0
+
+- name: Run containerized version of "{{ cerberus_image }}"
+  command: podman run --name=cerberus --net=host -v "{{ kubeconfig_path }}":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z -d "{{ cerberus_image }}"
+  when: not slack_integration
+
+- name: Run containerized version of "{{ cerberus_image }}" with slack integration
+  command: podman run --name=cerberus --net=host -v "{{ kubeconfig_path }}":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z --env SLACK_API_TOKEN="{{ slack_api_token }}" --env SLACK_CHANNEL="{{ slack_channel }}" -d "{{ cerberus_image }}"
+  when: slack_integration

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -281,38 +281,3 @@
       args:
         chdir: "{{ansible_user_dir}}/dittybopper"
   when: dittybopper_enable
-
-- name: Enable cerberus
-  block:
-    - name: Generate cerberus config file
-      template:
-        src: cerberus.j2
-        dest: "{{ cerberus_config_path }}"
-
-    - name: Install podman
-      yum:
-        name: podman
-        state: latest
-
-    - name: Pull "{{ cerberus_image }}" image
-      podman_image:
-        name: "{{ cerberus_image }}"
-        force: yes
-
-    - name: Check if cerberus is running
-      shell: podman ps | grep -w cerberus || podman ps -a | grep -w cerberus
-      register: cerberus_status
-      ignore_errors: yes
-
-    - name: Delete cerberus container if it exists
-      shell: podman rm -f cerberus
-      when: cerberus_status.rc == 0
-
-    - name: Run containerized version of "{{ cerberus_image }}"
-      command: podman run --name=cerberus --net=host -v "{{ kubeconfig_path }}":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z -d "{{ cerberus_image }}"
-      when: not slack_integration
-
-    - name: Run containerized version of "{{ cerberus_image }}" with slack integration
-      command: podman run --name=cerberus --net=host -v "{{ kubeconfig_path }}":/root/.kube/config:Z -v "{{ cerberus_config_path }}":/root/cerberus/config/config.yaml:Z --env SLACK_API_TOKEN="{{ slack_api_token }}" --env SLACK_CHANNEL="{{ slack_channel }}" -d "{{ cerberus_image }}"
-      when: slack_integration 
-  when: cerberus_enable

--- a/OCP-4.X/scale.yml
+++ b/OCP-4.X/scale.yml
@@ -10,6 +10,11 @@
   vars_files:
     - vars/scale.yml
   tasks:
+    - name: Verify cluster health with Cerberus
+      include_role:
+        name: "cerberus"
+      when: cerberus_url is defined and cerberus_url != ""
+
     - name: Get worker machineset names
       shell: |
         oc get machineset -n openshift-machine-api | egrep "\-worker\-|\-w\-" | awk '{print $1}'
@@ -69,3 +74,8 @@
     - name: Add additional label to worker nodes to provide ability to isolate workloads on workers
       shell: |
         oc label nodes --overwrite -l 'node-role.kubernetes.io/worker=' computenode=true
+    
+    - name: Verify cluster health with Cerberus
+      include_role:
+        name: "cerberus"
+      when: cerberus_url is defined and cerberus_url != ""

--- a/OCP-4.X/upgrade.yml
+++ b/OCP-4.X/upgrade.yml
@@ -15,6 +15,11 @@
     #   shell: |
     #     {%raw%}oc patch clusterversion/version --patch '{"spec":{"upstream":"{%endraw%}{{rhcos_upstream_url}}{%raw%}"}}' --type=merge{%endraw%}
 
+    - name: Verify cluster health with Cerberus
+      include_role:
+        name: "cerberus"
+      when: cerberus_url is defined and cerberus_url != ""
+
     - name: Initiate Upgrade
       shell: |
         oc adm upgrade --force={{force_upgrade}} --to-image={{rhcos_new_version_url}}:{{rhcos_new_version}}
@@ -44,3 +49,8 @@
       fail:
         msg: "Upgrade exceeded polling"
       when: clusterversion_upgrading.stdout.find("Cluster version is ") == -1
+
+    - name: Verify cluster health with Cerberus
+      include_role:
+        name: "cerberus"
+      when: cerberus_url is defined and cerberus_url != ""

--- a/OCP-4.X/vars/install-on-aws.yml
+++ b/OCP-4.X/vars/install-on-aws.yml
@@ -80,6 +80,9 @@ cerberus_config_path: "{{ lookup('env', 'CERBERUS_CONFIG_PATH')|default('~/cerbe
 
 # Cerberus image
 cerberus_image: "{{ lookup('env', 'CERBERUS_IMAGE')|default('quay.io/openshift-scale/cerberus:latest', true) }}"
+## If cerberus is running but not deployed by scaleci-deploy
+# Add the url of cerberus in the format "http://1.2.3.4:8080"
+cerberus_url: "{{ lookup('env', 'CERBERUS_URL')|default('http://0.0.0.0:8080') }}"
 
 # Cerberus configurations
 watch_nodes: "{{ lookup('env', 'WATCH_NODES')|default(true, true) }}"

--- a/OCP-4.X/vars/install-on-azure.yml
+++ b/OCP-4.X/vars/install-on-azure.yml
@@ -78,6 +78,9 @@ cerberus_config_path: "{{ lookup('env', 'CERBERUS_CONFIG_PATH')|default('~/cerbe
 
 # Cerberus image
 cerberus_image: "{{ lookup('env', 'CERBERUS_IMAGE')|default('quay.io/openshift-scale/cerberus:latest', true) }}"
+## If cerberus is running but not deployed by scaleci-deploy
+# Add the url of cerberus in the format "http://1.2.3.4:8080"
+cerberus_url: "{{ lookup('env', 'CERBERUS_URL')|default('http://0.0.0.0:8080') }}"
 
 # Cerberus configurations
 watch_nodes: "{{ lookup('env', 'WATCH_NODES')|default(true, true) }}"

--- a/OCP-4.X/vars/install-on-gcp.yml
+++ b/OCP-4.X/vars/install-on-gcp.yml
@@ -74,6 +74,9 @@ cerberus_config_path: "{{ lookup('env', 'CERBERUS_CONFIG_PATH')|default('~/cerbe
 
 # Cerberus image
 cerberus_image: "{{ lookup('env', 'CERBERUS_IMAGE')|default('quay.io/openshift-scale/cerberus:latest', true) }}"
+## If cerberus is running but not deployed by scaleci-deploy
+# Add the url of cerberus in the format "http://1.2.3.4:8080"
+cerberus_url: "{{ lookup('env', 'CERBERUS_URL')|default('http://0.0.0.0:8080') }}"
 
 # Cerberus configurations
 watch_nodes: "{{ lookup('env', 'WATCH_NODES')|default(true, true) }}"

--- a/OCP-4.X/vars/install-on-osp.yml
+++ b/OCP-4.X/vars/install-on-osp.yml
@@ -65,6 +65,9 @@ cerberus_config_path: "{{ lookup('env', 'CERBERUS_CONFIG_PATH')|default('~/cerbe
 
 # Cerberus image
 cerberus_image: "{{ lookup('env', 'CERBERUS_IMAGE')|default('quay.io/openshift-scale/cerberus:latest', true) }}"
+## If cerberus is running but not deployed by scaleci-deploy
+# Add the url of cerberus in the format "http://1.2.3.4:8080"
+cerberus_url: "{{ lookup('env', 'CERBERUS_URL')|default('http://0.0.0.0:8080') }}"
 
 # Cerberus configurations
 watch_nodes: "{{ lookup('env', 'WATCH_NODES')|default(true, true) }}"

--- a/OCP-4.X/vars/scale.yml
+++ b/OCP-4.X/vars/scale.yml
@@ -17,3 +17,7 @@ rhcos_metadata_label_prefix: "{{ lookup('env', 'RHCOS_METADATA_LABEL_PREFIX')|de
 
 # Total desired count of nodes
 rhcos_worker_count: "{{ lookup('env', 'RHCOS_WORKER_COUNT')|default(5, true) }}"
+
+
+## To enable Cerberus integration add the url of cerberus in the format "http://1.2.3.4:8080"
+cerberus_url: "{{ lookup('env', 'CERBERUS_URL')|default('') }}"

--- a/OCP-4.X/vars/upgrade.yml
+++ b/OCP-4.X/vars/upgrade.yml
@@ -18,3 +18,6 @@ poll_attempts: "{{ lookup('env', 'POLL_ATTEMPTS')|default(1800, true) }}"
 rhcos_new_version_url: "{{ lookup('env', 'RHCOS_NEW_VERSION_URL')|default('quay.io/openshift-release-dev/ocp-release', true) }}"
 rhcos_new_version: "{{ lookup('env', 'RHCOS_NEW_VERSION')|default('4.0.0-0.10', true) }}"
 force_upgrade: "{{ lookup('env', 'FORCE_UPGRADE')|default(false, true)|bool|lower }}"
+
+## To enable Cerberus integration add the url of cerberus in the format "http://1.2.3.4:8080"
+cerberus_url: "{{ lookup('env', 'CERBERUS_URL')|default('') }}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,3 +40,12 @@ echo "${ORCHESTRATION_HOST}" >> inventory
 
 ansible-playbook -vv -i inventory OCP-4.X/install-on-aws.yml
 ```
+
+## Cerberus Integration
+
+What is Cerberus? [Cerberus](https://github.com/openshift-scale/cerberus) is a project that will watch an Openshift/Kubernernetes cluster
+for dead nodes, component failures, etc and provide a healthly/unhealthy (True/False) signal.
+
+Cerberus is optionally used for all install/scale/upgrades by defining the CERBERUS_URL variable in the format "http://1.2.3.4:8080"
+
+For installation and startup instructions for Cerberus please see [https://github.com/openshift-scale/cerberus](https://github.com/openshift-scale/cerberus)

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -231,6 +231,10 @@ Path to cerberus_config.
 Default: `quay.io/openshift-scale/cerberus:latest`
 Image to be pulled to run the containerized version of cerberus.
 
+### CERBERUS_URL
+Default: "http://0.0.0.0:8080"
+Optional arguement for cerberus configuration if cerberus is using a different URL than the default.
+
 ### WATCH NODES
 Default: `true`
 Set to True for the cerberus to monitor the cluster nodes.
@@ -342,3 +346,4 @@ The storage size for the alert manager servers.
 ### KUBECONFIG_AUTH_DIR_PATH
 Default: No default.
 For use with Flexy built clusters, in which only the post-install steps are ran.
+

--- a/docs/ocp4_azure.md
+++ b/docs/ocp4_azure.md
@@ -211,6 +211,10 @@ Path to cerberus_config.
 Default: `quay.io/openshift-scale/cerberus:latest`
 Image to be pulled to run the containerized version of cerberus.
 
+### CERBERUS_URL
+Default: "http://0.0.0.0:8080"
+Optional arguement for cerberus configuration if cerberus is using a different URL than the default.
+
 ### WATCH NODES
 Default: `true`
 Set to True for the cerberus to monitor the cluster nodes.

--- a/docs/ocp4_gcp.md
+++ b/docs/ocp4_gcp.md
@@ -207,6 +207,10 @@ Path to cerberus_config.
 Default: `quay.io/openshift-scale/cerberus:latest`
 Image to be pulled to run the containerized version of cerberus.
 
+### CERBERUS_URL
+Default: "http://0.0.0.0:8080"
+Optional arguement for cerberus configuration if cerberus is using a different URL than the default.
+
 ### WATCH NODES
 Default: `true`
 Set to True for the cerberus to monitor the cluster nodes.

--- a/docs/ocp4_osp.md
+++ b/docs/ocp4_osp.md
@@ -179,6 +179,10 @@ Path to cerberus_config.
 Default: `quay.io/openshift-scale/cerberus:latest`
 Image to be pulled to run the containerized version of cerberus.
 
+### CERBERUS_URL
+Default: "http://0.0.0.0:8080"
+Optional arguement for cerberus configuration if cerberus is using a different URL than the default.
+
 ### WATCH NODES
 Default: `true`
 Set to True for the cerberus to monitor the cluster nodes.

--- a/docs/ocp4_scale.md
+++ b/docs/ocp4_scale.md
@@ -36,3 +36,7 @@ The prefix used in machinesets. Usually this is `machine.openshift.io` however i
 ### RHCOS_WORKER_COUNT
 Default: `5`  
 The total desired count of nodes.
+
+### CERBERUS_URL
+Default: ""
+To enable Cerberus integration add the url of cerberus in the format http://1.2.3.4:8080

--- a/docs/ocp4_upgrade.md
+++ b/docs/ocp4_upgrade.md
@@ -40,3 +40,7 @@ The new version to upgrade to. Check [https://openshift-release.svc.ci.openshift
 ### FORCE_UPGRADE
 Default: `false`  
 Determines the `--force` flag value for the `oc adm upgrade` command to initiate an upgrade.
+
+### CERBERUS_URL
+Default: ""
+To enable Cerberus integration add the url of cerberus in the format http://1.2.3.4:8080


### PR DESCRIPTION
This adds an optional CERBERUS_URL variable that can be passed to all install/upgrade/scale jobs. If enabled then it will check the status of the cluster prior and post activity. It fails if Cerberus returns False during any of the checks