### PR TITLE
minor fixes to allow for gcp to work

### DIFF
--- a/OCP-4.X/roles/install-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-gcp/tasks/main.yml
@@ -110,10 +110,6 @@
     path: "{{ ansible_user_dir }}/.gcp"
     state: directory
 
-- name: Login GCP account via service account (For GCP CLI interactions) and set the default project
-  shell: |
-    gcloud auth activate-service-account {{ gcp_service_account }} --key-file={{ gcp_auth_key_file }} --project={{ gcp_project }}
-
 - name: Read contents of local ssh public key
   slurp:
     src: "{{openshift_install_ssh_pub_key_file}}"
@@ -129,7 +125,7 @@
     - "{{ansible_user_dir}}/scale-ci-deploy/install-config_gcp.yaml"
 
 - block:
-   - name: Fetch the openshift-install binary tarball 
+   - name: Fetch the openshift-install binary tarball
      get_url:
        url: "{{ openshift_install_binary_url }}"
        dest: "{{ansible_user_dir}}/scale-ci-deploy/bin/"
@@ -144,6 +140,7 @@
      shell: |
        set -o pipefail
        cd {{ansible_user_dir}}/scale-ci-deploy
+       export GOOGLE_CREDENTIALS={{ gcp_auth_key_file }}
        bin/openshift-install create cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
   when: openshift_install_binary_url != ""
 

--- a/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
@@ -25,9 +25,17 @@
         groups: workload
   when: openshift_toggle_workload_node|bool
 
+- name: set service account
+  shell: |
+     gcloud config set account {{ gcp_service_account }}
+
+- name: set project
+  shell: |
+     gcloud config set project {{ gcp_project }}
+
 - name: Get network name
   shell: |
-     gcloud compute networks list | grep {{ rhcos_cluster_name.stdout }} | awk '{print $1}' 
+     gcloud compute networks list | grep {{ rhcos_cluster_name.stdout }} | awk '{print $1}'
   register: gcp_network
 
 - name: Create firewall rule for ICMP
@@ -61,4 +69,3 @@
     flat: true
   when:
     - kubeconfig_auth_dir_path == ""
-

--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -83,6 +83,16 @@
         - src: gcp-workload-node-machineset.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-deploy/workload-node-machineset.yml"
           toggle: "{{openshift_toggle_workload_node}}"
+        - src: gcp-ssd-sc.yml.j2
+          dest: "{{ansible_user_dir}}/scale-ci-deploy/pd-ssd-sc.yml"
+          toggle: true
+
+    - name: (GCP) Create faster ssd sc
+      shell: |
+        oc create -f {{ item.sc }}
+      with_items:
+        - sc: "{{ansible_user_dir}}/scale-ci-deploy/pd-ssd-sc.yml"
+
   when: platform == "gcp"
 
 - name: (OSP) Template out machineset yamls

--- a/OCP-4.X/roles/post-install/templates/gcp-ssd-sc.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-ssd-sc.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: pd-ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd

--- a/OCP-4.X/vars/install-on-gcp.yml
+++ b/OCP-4.X/vars/install-on-gcp.yml
@@ -115,9 +115,9 @@ openshift_workload_node_volume_size: "{{ lookup('env', 'OPENSHIFT_WORKLOAD_NODE_
 openshift_workload_node_volume_type: "{{ lookup('env', 'OPENSHIFT_WORKLOAD_NODE_VOLUME_TYPE')|default('pd-ssd', true) }}"
 
 openshift_prometheus_retention_period: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_RETENTION_PERIOD')|default('15d', true) }}"
-openshift_prometheus_storage_class: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_STORAGE_CLASS')|default('pd-ssd', true) }}"
+openshift_prometheus_storage_class: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_STORAGE_CLASS')|default('standard', true) }}"
 openshift_prometheus_storage_size: "{{ lookup('env', 'OPENSHIFT_PROMETHEUS_STORAGE_SIZE')|default('10Gi', true) }}"
-openshift_alertmanager_storage_class: "{{ lookup('env', 'OPENSHIFT_ALERTMANAGER_STORAGE_CLASS')|default('pd-ssd', true) }}"
+openshift_alertmanager_storage_class: "{{ lookup('env', 'OPENSHIFT_ALERTMANAGER_STORAGE_CLASS')|default('standard', true) }}"
 openshift_alertmanager_storage_size: "{{ lookup('env', 'OPENSHIFT_ALERTMANAGER_STORAGE_SIZE')|default('2Gi', true) }}"
 
 ## To specify an alternate auth dir containing kubeconfig, e.g. from GCP cluster installed by Flexy,


### PR DESCRIPTION
1. update default sc to standard for the monitoring stack related pv
2. allow for install of pd-ssd sc class
3. export credentials instead of doing a login