### PR TITLE
get google-sdk file from absolute path

### DIFF
--- a/OCP-4.X/roles/install-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-gcp/tasks/main.yml
@@ -44,7 +44,7 @@
   copy:
     src: "{{ role_path }}/files/google-cloud-sdk.repo"
     dest: /etc/yum.repos.d/
-    remote_src: true
+    remote_src: false
 
 - name: Install dependencies
   package:
@@ -110,6 +110,9 @@
     path: "{{ ansible_user_dir }}/.gcp"
     state: directory
 
+- name: Login GCP account via service account (For GCP CLI interactions) and set the default project
+  shell: gcloud auth activate-service-account {{ gcp_service_account }} --key-file={{ gcp_auth_key_file }} --project={{ gcp_project }}
+
 - name: Read contents of local ssh public key
   slurp:
     src: "{{openshift_install_ssh_pub_key_file}}"
@@ -136,7 +139,7 @@
        cd {{ansible_user_dir}}/scale-ci-deploy/bin
        ls *.tar.gz | xargs -I % sh -c 'tar -xvf %'
        chmod +x openshift-install
-   - name: Run openshift installer on aws using the provided binary
+   - name: Run openshift installer on gcp using the provided binary
      shell: |
        set -o pipefail
        cd {{ansible_user_dir}}/scale-ci-deploy

--- a/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-gcp/tasks/main.yml
@@ -40,19 +40,19 @@
 
 - name: Create firewall rule for ICMP
   shell: |
-    gcloud compute firewall-rules create scale-ci-icmp-{{ rhcos_cluster_name.stdout }} --network {{ gcp_network.stdout }} --priority 101 --description "scale-ci allow icmp" --allow icmp
+    gcloud compute firewall-rules create {{ rhcos_cluster_name.stdout }}-scale-ci-icmp --network {{ gcp_network.stdout }} --priority 101 --description "scale-ci allow icmp" --allow icmp
 
 - name: Create firewall rule for ssh (22)
   shell: |
-    gcloud compute firewall-rules create scale-ci-ssh-{{ rhcos_cluster_name.stdout }} --network {{ gcp_network.stdout }} --direction INGRESS --priority 102 --description "scale-ci allow ssh" --allow tcp:22
+    gcloud compute firewall-rules create {{ rhcos_cluster_name.stdout }}-scale-ci-ssh --network {{ gcp_network.stdout }} --direction INGRESS --priority 102 --description "scale-ci allow ssh" --allow tcp:22
 
 - name: Create firewall rule for pbench-agent ssh (2022)
   shell: |
-    gcloud compute firewall-rules create scale-ci-pbench-{{ rhcos_cluster_name.stdout }} --network {{ gcp_network.stdout }} --direction INGRESS --priority 103 --description "scale-ci allow pbench-agents" --allow tcp:2022
+    gcloud compute firewall-rules create {{ rhcos_cluster_name.stdout }}-scale-ci-pbench --network {{ gcp_network.stdout }} --direction INGRESS --priority 103 --description "scale-ci allow pbench-agents" --allow tcp:2022
 
 - name: Create firewall rule for tcp,udp network tests (20000-20109)
   shell: |
-    gcloud compute firewall-rules create scale-ci-net-{{ rhcos_cluster_name.stdout }} --network {{ gcp_network.stdout }} --direction INGRESS --priority 104 --description "scale-ci allow tcp,udp network tests" --rules tcp,udp:20000-20109 --action allow
+    gcloud compute firewall-rules create {{ rhcos_cluster_name.stdout }}-scale-ci-net --network {{ gcp_network.stdout }} --direction INGRESS --priority 104 --description "scale-ci allow tcp,udp network tests" --rules tcp,udp:20000-20109 --action allow
 
 # Typically `net.ipv4.ip_local_port_range` is set to `32768 60999` in which uperf will pick a few random ports to send flags over.
 # Currently there is no method outside of sysctls to control those ports
@@ -60,7 +60,7 @@
 
 - name: Create firewall rule for tcp,udp hostnetwork tests (32768-60999)
   shell: |
-    gcloud compute firewall-rules create scale-ci-hostnet-{{ rhcos_cluster_name.stdout }} --network {{ gcp_network.stdout }}  --priority 105 --description "scale-ci allow tcp,udp hostnetwork tests" --rules tcp,udp:32768-60999 --action allow
+    gcloud compute firewall-rules create {{ rhcos_cluster_name.stdout }}-scale-ci-hostnet --network {{ gcp_network.stdout }}  --priority 105 --description "scale-ci allow tcp,udp hostnetwork tests" --rules tcp,udp:32768-60999 --action allow
 
 - name: Get the kubeconfig off of the orchestration host
   fetch:


### PR DESCRIPTION
copy google sdk file from jenkins-slave to jump host (to avoid https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/ATS-SCALE-CI-TEST/184/console)
Firewall rule names have the cluster name pre fixed instead of post fixed so that cleanup is able to delete these firewall rules 