### PR TITLE
Scrape payload info from url in addition to umb message

### DIFF
--- a/OCP-4.X/build-info.yml
+++ b/OCP-4.X/build-info.yml
@@ -12,15 +12,32 @@
         body_format: json
       register: build_info
 
-    - name: Dump the captured build info to a file
-      copy:
-        content: "{{ (build_info.content|from_json) }}"
-        dest: "{{ build_info_destination }}/build_info.json"
+    - block:
+        - name: Dump the captured build info to a file
+          copy:
+            content: "{{ (build_info.content|from_json) }}"
+            dest: "{{ build_info_destination }}/build_info.json"
 
-    - name: Filter and capture the payload to a file
-      copy:
-        content: "{{ (build_info.content|from_json).msg.pullSpec }}"
-        dest: "{{ build_info_destination }}/payload"
+        - name: Set payload info as fact
+          set_fact:
+            payload_info: "{{ (build_info.content|from_json).msg.pullSpec }}"
+
+        - name: Filter and capture the payload to a file
+          copy:
+            content: "{{ payload_info }}"
+            dest: "{{ build_info_destination }}/payload"
+      when: umb_message_format| bool
+
+    - block:
+        - name: Filter and capture the payload to a file
+          copy:
+            content: "{{ build_info.content }}"
+            dest: "{{ build_info_destination }}/payload"
+
+        - name: Set payload info as fact
+          set_fact:
+            payload_info: "{{ build_info.content }}"
+      when: not umb_message_format| bool
 
     - name: Check if the file with the info about the previous payload exists
       stat:
@@ -54,7 +71,7 @@
 
         - name: Update the previous payload file with the current payload info for the next runs after comparing and setting the status file when they don't match
           copy:
-            content: "{{ (build_info.content|from_json).msg.pullSpec }}"
+            content: "{{ payload_info }}"
             dest: "{{ build_info_destination }}/payload.previous"
           when: previous_payload.content| b64decode| trim != current_payload.content| b64decode| trim
       when: previous_payload_file.stat.exists == True
@@ -68,7 +85,7 @@
 
         - name: Populate the previous payload info
           copy:
-            content: "{{ (build_info.content|from_json).msg.pullSpec }}"
+            content: "{{ payload_info }}"
             dest: "{{ build_info_destination }}/payload.previous"
       when: previous_payload_file.stat.exists == False
 

--- a/OCP-4.X/vars/build-info.yml
+++ b/OCP-4.X/vars/build-info.yml
@@ -9,6 +9,9 @@ orchestration_user: "{{ lookup('env', 'ORCHESTRATION_USER')|default('root', true
 ###############################################################################
 # Build info vars
 ###############################################################################
+# Type of the message containing payload details
+umb_message_format: "{{ lookup('env', 'UMB_MESSAGE_FORMAT')|default(false, true) }}"
+
 # Url to query for the build info
 build_info_url: "{{ lookup('env', 'BUILD_INFO_URL') }}"
 


### PR DESCRIPTION
This commit enables user to pass either an url or the umb message
containing the payload info.