### PR TITLE
Data server

### DIFF
--- a/OCP-4.X/roles/data_server_install/tasks/main.yml
+++ b/OCP-4.X/roles/data_server_install/tasks/main.yml
@@ -1,38 +1,106 @@
 ---
-- name: Install podman
-  package:
-    name: podman
+- name: update pip and pipx on RHEL/CentOS
+  pip: 
+    name: 
+      - pip
+      - pipx
     state: latest
+    executable: pip3
+  when: ansible_facts['distribution'] == 'RedHat' or ansible_facts['distribution'] == 'CentOS'
+
+- name: update pip and pipx on Fedora
+  pip: 
+    name: 
+      - pip
+      - pipx
+    state: latest
+    executable: pip
+  when: ansible_facts['distribution'] == 'Fedora'
+
+- name: install container engine and git
+  become: yes
+  package: 
+    name:
+      - podman
+      - git
+    state: present
+
+- name: Get snappy cli
+  command: pipx install --force git+https://github.com/openshift-scale/data-server-cli.git
+
+- name: Update path to include cli app
+  command: pipx ensurepath
+
+- name: Install snappy cli
+  command: snappy install
+
+- name: Create results directory at host root
+  file:
+    path: "{{ data_server_root_path }}/results"
+    state: directory
+    mode: '0755'
 
 - name: Pull "{{ data_server_image }}" image
   podman_image:
     name: "{{ data_server_image }}"
     force: "yes"
 
-- name: Check if data server is on the machine
-  shell: podman ps -a | grep -w snappy-data-server
-  register: data_server_status
+- name: Remove old pod
+  command: podman pod rm -f snappy
   ignore_errors: yes
 
-- name: Delete data server container if it exists
-  shell: podman rm -f data_server
-  when: data_server_status.rc == 0
+- name: Remove old postgres volume
+  command: podman volume rm pg-snappy
   ignore_errors: yes
+    
+- name: Create a new volume for postgres service
+  command: podman volume create pg-snappy
 
-- name: Create results directory at host root if it does not exist
-  file:
-    path: "{{ data_server_root_path }}/results"
-    state: directory
-    mode: '0755'
+- name: Create a pod for container communication
+  command: >-
+    podman pod create
+    --name snappy
+    --publish "{{ data_server_port }}"
 
-- name: Run "{{ data_server_image }}" with a shared results directory on the host
-  command: >- 
+- name: Run postgres service
+  command: >-
     podman run
     --detach
-    --name=data_server
-    --net=host 
+    --env POSTGRES_PASSWORD="{{ postgres_password }}"
+    --name snappy_db
+    --pod snappy
+    --volume pg-snappy:/var/lib/postgresql/data
+    docker.io/library/postgres:12.3-alpine
+
+- name: Seed database with users
+  command: >-
+    podman run
+    --detach
+    --env DATA_SERVER_LOG_LVL="{{ data_server_log_lvl }}"
     --env DATA_SERVER_PUBLIC_HOST="{{ data_server_public_host }}"
     --env DATA_SERVER_PORT="{{ data_server_port }}"
+    --env DATA_SERVER_SECRET="{{ data_server_secret }}"
+    --env FIRST_SUPERUSER="{{ first_superuser }}"
+    --env FIRST_SUPERUSER_PASSWORD="{{ first_superuser_password }}"
+    --env POSTGRES_PASSWORD="{{ postgres_password }}"
+    --env POSTGRES_PORT=5432
+    --env POSTGRES_SERVER=localhost
+    --pod snappy
+    --rm
+    "{{ data_server_image }}" ./scripts/prestart
+
+- name: Run data server
+  command: >-
+    podman run
+    --detach
     --env DATA_SERVER_LOG_LVL="{{ data_server_log_lvl }}"
-    --volume "{{ data_server_root_path }}"/results:/data_server/app/results:z
+    --env DATA_SERVER_PUBLIC_HOST="{{ data_server_public_host }}"
+    --env DATA_SERVER_PORT="{{ data_server_port }}"
+    --env DATA_SERVER_SECRET="{{ data_server_secret }}"
+    --env POSTGRES_PASSWORD="{{ postgres_password }}"
+    --env POSTGRES_PORT=5432
+    --env POSTGRES_SERVER=localhost
+    --name snappy_http
+    --pod snappy
+    --volume "{{ data_server_root_path }}"/results:/data_server/app/app/results:z
     "{{ data_server_image }}"

--- a/OCP-4.X/vars/install-on-aws.yml
+++ b/OCP-4.X/vars/install-on-aws.yml
@@ -141,10 +141,14 @@ kubeconfig_auth_dir_path: "{{ lookup('env', 'KUBECONFIG_AUTH_DIR_PATH') }}"
 
 data_server_enable: "{{ lookup('env', 'DATA_SERVER_ENABLE')|default(false, true) }}"
 data_server_image: "{{ lookup('env', 'DATA_SERVER_IMAGE')|default('quay.io/openshift-scale/snappy-data-server:latest', true) }}"
-data_server_root_path: "{{ lookup('env', 'DATA_SERVER_ROOT_PATH')|default('/root/data_server', true) }}"
-data_server_port: "{{ lookup('env', 'DATA_SERVER_PORT')|default(7070, true) }}"
 data_server_log_lvl: "{{ lookup('env', 'DATA_SERVER_LOG_LVL')|default('info', true) }}"
+data_server_port: "{{ lookup('env', 'DATA_SERVER_PORT')|default(7070, true) }}"
 data_server_public_host: "{{ lookup('env', 'DATA_SERVER_PUBLIC_HOST')|default('localhost', true) }}"
+data_server_root_path: "{{ lookup('env', 'DATA_SERVER_ROOT_PATH')|default('~/data_server', true) }}"
+data_server_secret: "{{ lookup('env', 'DATA_SERVER_SECRET') }}"
+first_superuser: "{{ lookup('env', 'FIRST_SUPERUSER') }}"
+first_superuser_password: "{{ lookup('env', 'FIRST_SUPERUSER_PASSWORD') }}"
+postgres_password: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
 
 # FIPS
 fips: "{{ lookup('env', 'FIPS')|default(false, true) }}"

--- a/OCP-4.X/vars/install-on-azure.yml
+++ b/OCP-4.X/vars/install-on-azure.yml
@@ -137,10 +137,14 @@ kubeconfig_auth_dir_path: "{{ lookup('env', 'KUBECONFIG_AUTH_DIR_PATH') }}"
 
 data_server_enable: "{{ lookup('env', 'DATA_SERVER_ENABLE')|default(false, true) }}"
 data_server_image: "{{ lookup('env', 'DATA_SERVER_IMAGE')|default('quay.io/openshift-scale/snappy-data-server:latest', true) }}"
-data_server_root_path: "{{ lookup('env', 'DATA_SERVER_ROOT_PATH')|default('/root/data_server', true) }}"
+data_server_log_lvl: "{{ lookup('env', 'DATA_SERVER_LOG_LVL')|default('info', true) }}"
 data_server_port: "{{ lookup('env', 'DATA_SERVER_PORT')|default(7070, true) }}"
-data_server_log_lvl: "{{ lookup('env', 'DATA_SERVER_LOG_LVL')|default(info, true) }}"
-data_server_public_host: "{{ lookup('env', 'DATA_SERVER_PUBLIC_HOST')|default(localhost, true) }}"
+data_server_public_host: "{{ lookup('env', 'DATA_SERVER_PUBLIC_HOST')|default('localhost', true) }}"
+data_server_root_path: "{{ lookup('env', 'DATA_SERVER_ROOT_PATH')|default('~/data_server', true) }}"
+data_server_secret: "{{ lookup('env', 'DATA_SERVER_SECRET') }}"
+first_superuser: "{{ lookup('env', 'FIRST_SUPERUSER') }}"
+first_superuser_password: "{{ lookup('env', 'FIRST_SUPERUSER_PASSWORD') }}"
+postgres_password: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
 
 
 # FIPS

--- a/OCP-4.X/vars/install-on-gcp.yml
+++ b/OCP-4.X/vars/install-on-gcp.yml
@@ -136,10 +136,14 @@ kubeconfig_auth_dir_path: "{{ lookup('env', 'KUBECONFIG_AUTH_DIR_PATH') }}"
 
 data_server_enable: "{{ lookup('env', 'DATA_SERVER_ENABLE')|default(false, true) }}"
 data_server_image: "{{ lookup('env', 'DATA_SERVER_IMAGE')|default('quay.io/openshift-scale/snappy-data-server:latest', true) }}"
-data_server_root_path: "{{ lookup('env', 'DATA_SERVER_ROOT_PATH')|default('/root/data_server', true) }}"
+data_server_log_lvl: "{{ lookup('env', 'DATA_SERVER_LOG_LVL')|default('info', true) }}"
 data_server_port: "{{ lookup('env', 'DATA_SERVER_PORT')|default(7070, true) }}"
-data_server_log_lvl: "{{ lookup('env', 'DATA_SERVER_LOG_LVL')|default(info, true) }}"
-data_server_public_host: "{{ lookup('env', 'DATA_SERVER_PUBLIC_HOST')|default(localhost, true) }}"
+data_server_public_host: "{{ lookup('env', 'DATA_SERVER_PUBLIC_HOST')|default('localhost', true) }}"
+data_server_root_path: "{{ lookup('env', 'DATA_SERVER_ROOT_PATH')|default('~/data_server', true) }}"
+data_server_secret: "{{ lookup('env', 'DATA_SERVER_SECRET') }}"
+first_superuser: "{{ lookup('env', 'FIRST_SUPERUSER') }}"
+first_superuser_password: "{{ lookup('env', 'FIRST_SUPERUSER_PASSWORD') }}"
+postgres_password: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
 
 # FIPS
 fips: "{{ lookup('env', 'FIPS')|default(false, true) }}"

--- a/OCP-4.X/vars/install-on-osp.yml
+++ b/OCP-4.X/vars/install-on-osp.yml
@@ -117,10 +117,15 @@ openshift_alertmanager_storage_size: "{{ lookup('env', 'ALERTMANAGER_STORAGE_SIZ
 
 data_server_enable: "{{ lookup('env', 'DATA_SERVER_ENABLE')|default(false, true) }}"
 data_server_image: "{{ lookup('env', 'DATA_SERVER_IMAGE')|default('quay.io/openshift-scale/snappy-data-server:latest', true) }}"
-data_server_root_path: "{{ lookup('env', 'DATA_SERVER_ROOT_PATH')|default('/root/data_server', true) }}"
+data_server_log_lvl: "{{ lookup('env', 'DATA_SERVER_LOG_LVL')|default('info', true) }}"
 data_server_port: "{{ lookup('env', 'DATA_SERVER_PORT')|default(7070, true) }}"
-data_server_log_lvl: "{{ lookup('env', 'DATA_SERVER_LOG_LVL')|default(info, true) }}"
-data_server_public_host: "{{ lookup('env', 'DATA_SERVER_PUBLIC_HOST')|default(localhost, true) }}"
+data_server_public_host: "{{ lookup('env', 'DATA_SERVER_PUBLIC_HOST')|default('localhost', true) }}"
+data_server_root_path: "{{ lookup('env', 'DATA_SERVER_ROOT_PATH')|default('~/data_server', true) }}"
+data_server_secret: "{{ lookup('env', 'DATA_SERVER_SECRET') }}"
+first_superuser: "{{ lookup('env', 'FIRST_SUPERUSER') }}"
+first_superuser_password: "{{ lookup('env', 'FIRST_SUPERUSER_PASSWORD') }}"
+postgres_password: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
+
 
 # FIPS
 fips: "{{ lookup('env', 'FIPS')|default(false, true) }}"

--- a/docs/ocp4_aws.md
+++ b/docs/ocp4_aws.md
@@ -391,22 +391,38 @@ For use with Flexy built clusters, in which only the post-install steps are ran
 Default: `false`
 Controls whether the data server is launched.
 
-### DATA_SERVER_ROOT_PATH
-Default: `/root/data_server`
-Absolute path to the data server's host's directory.
-
 ### DATA_SERVER_IMAGE
 Default: `quay.io/openshift-scale/snappy-data-server`
 Latest, maintained image of the snappy data server.
+
+### DATA_SERVER_LOG_LVL
+Default: `info`  
+Data server log level. Current [Uvicorn server](https://www.uvicorn.org) **options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.
+
+### DATA_SERVER_PORT
+Default: `7070`  
+Data server service port.
 
 ### DATA_SERVER_PUBLIC_HOST
 Default: `localhost`  
 URL to public host of data server.
 
-### DATA_SERVER_PORT
-Default: `7070`  
-Service port.
+### DATA_SERVER_ROOT_PATH
+Default: `~/data_server`
+Absolute path to the data server's host's directory.
 
-### DATA_SERVER_LOG_LVL
-Default: `info`  
-Data server log level. Current [Uvicorn server](https://www.uvicorn.org) **options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.
+### DATA_SERVER_SECRET
+Default: No default.
+Secret to encode passwords in database.
+
+### FIRST_SUPERUSER
+Default: No default.
+Username for the first super user.
+
+### FIRST_SUPERUSER_PASSWORD
+Default: No default.
+Password for the first super user.
+
+### POSTGRES_PASSWORD
+Default: No default.
+Postgresql database super user password.

--- a/docs/ocp4_azure.md
+++ b/docs/ocp4_azure.md
@@ -363,23 +363,38 @@ For use with Flexy built clusters, in which only the post-install steps are ran.
 Default: `false`
 Controls whether the data server is launched.
 
-### DATA_SERVER_ROOT_PATH
-Default: `/root/data_server`
-Absolute path to the data server's host's directory.
-
 ### DATA_SERVER_IMAGE
 Default: `quay.io/openshift-scale/snappy-data-server`
 Latest, maintained image of the snappy data server.
-
-### DATA_SERVER_PUBLIC_HOST
-Default: `localhost`  
-URL to public host of data server.
-
-### DATA_SERVER_PORT
-Default: `7070`  
-Service port.
 
 ### DATA_SERVER_LOG_LVL
 Default: `info`  
 Data server log level. Current [Uvicorn server](https://www.uvicorn.org) **options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.
 
+### DATA_SERVER_PORT
+Default: `7070`  
+Data server service port.
+
+### DATA_SERVER_PUBLIC_HOST
+Default: `localhost`  
+URL to public host of data server.
+
+### DATA_SERVER_ROOT_PATH
+Default: `~/data_server`
+Absolute path to the data server's host's directory.
+
+### DATA_SERVER_SECRET
+Default: No default.
+Secret to encode passwords in database.
+
+### FIRST_SUPERUSER
+Default: No default.
+Username for the first super user.
+
+### FIRST_SUPERUSER_PASSWORD
+Default: No default.
+Password for the first super user.
+
+### POSTGRES_PASSWORD
+Default: No default.
+Postgresql database super user password.

--- a/docs/ocp4_gcp.md
+++ b/docs/ocp4_gcp.md
@@ -250,7 +250,10 @@ The prometheus url.
 ### PROMETHEUS_BEARER_TOKEN
 Default: `''`
 The prometheus bearer token is needed to authenticate with prometheus.
-
+data_server_root_path: "{{ lookup('env', 'DATA_SERVER_ROOT_PATH')|default('/root/data_server', true) }}"
+data_server_port: "{{ lookup('env', 'DATA_SERVER_PORT')|default(7070, true) }}"
+data_server_log_lvl: "{{ lookup('env', 'DATA_SERVER_LOG_LVL')|default(info, true) }}"
+data_server_public_host: "{{ lookup('env', 'DATA_SERVER_PUBLIC_HOST')|default(localhost, true) }}"
 ### SLACK_INTEGRATION
 Default: `false`
 When enabled, cerberus reports the the failed interations and sends the report for the same on a slack channel.
@@ -359,22 +362,38 @@ For use with Flexy built clusters, in which only the post-install steps are ran.
 Default: `false`
 Controls whether the data server is launched.
 
-### DATA_SERVER_ROOT_PATH
-Default: `/root/data_server`
-Absolute path to the data server's host's directory.
-
 ### DATA_SERVER_IMAGE
 Default: `quay.io/openshift-scale/snappy-data-server`
 Latest, maintained image of the snappy data server.
+
+### DATA_SERVER_LOG_LVL
+Default: `info`  
+Data server log level. Current [Uvicorn server](https://www.uvicorn.org) **options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.
+
+### DATA_SERVER_PORT
+Default: `7070`  
+Data server service port.
 
 ### DATA_SERVER_PUBLIC_HOST
 Default: `localhost`  
 URL to public host of data server.
 
-### DATA_SERVER_PORT
-Default: `7070`  
-Service port.
+### DATA_SERVER_ROOT_PATH
+Default: `~/data_server`
+Absolute path to the data server's host's directory.
 
-### DATA_SERVER_LOG_LVL
-Default: `info`  
-Data server log level. Current [Uvicorn server](https://www.uvicorn.org) **options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.
+### DATA_SERVER_SECRET
+Default: No default.
+Secret to encode passwords in database.
+
+### FIRST_SUPERUSER
+Default: No default.
+Username for the first super user.
+
+### FIRST_SUPERUSER_PASSWORD
+Default: No default.
+Password for the first super user.
+
+### POSTGRES_PASSWORD
+Default: No default.
+Postgresql database super user password.

--- a/docs/ocp4_osp.md
+++ b/docs/ocp4_osp.md
@@ -354,22 +354,38 @@ Determines if the image will be deleted from Glance on the OpenStack Cloud.
 Default: `false`
 Controls whether the data server is launched.
 
-### DATA_SERVER_ROOT_PATH
-Default: `/root/data_server`
-Absolute path to the data server's host's directory.
-
 ### DATA_SERVER_IMAGE
 Default: `quay.io/openshift-scale/snappy-data-server`
 Latest, maintained image of the snappy data server.
+
+### DATA_SERVER_LOG_LVL
+Default: `info`  
+Data server log level. Current [Uvicorn server](https://www.uvicorn.org) **options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.
+
+### DATA_SERVER_PORT
+Default: `7070`  
+Data server service port.
 
 ### DATA_SERVER_PUBLIC_HOST
 Default: `localhost`  
 URL to public host of data server.
 
-### DATA_SERVER_PORT
-Default: `7070`  
-Service port.
+### DATA_SERVER_ROOT_PATH
+Default: `~/data_server`
+Absolute path to the data server's host's directory.
 
-### DATA_SERVER_LOG_LVL
-Default: `info`  
-Data server log level. Current [Uvicorn server](https://www.uvicorn.org) **options:** *'critical', 'error', 'warning', 'info', 'debug', 'trace'.
+### DATA_SERVER_SECRET
+Default: No default.
+Secret to encode passwords in database.
+
+### FIRST_SUPERUSER
+Default: No default.
+Username for the first super user.
+
+### FIRST_SUPERUSER_PASSWORD
+Default: No default.
+Password for the first super user.
+
+### POSTGRES_PASSWORD
+Default: No default.
+Postgresql database super user password.


### PR DESCRIPTION
Update data server installation to reflect changes in data server dependencies, podman for orchestration, and [snappy cli](https://github.com/mfleader/snappyCLI). Newest version of the [data server](https://github.com/mfleader/snappy-data-server/tree/auth-sqa) uses a postgres service container to store user information for authentication.

The commit changes looks a little weird because the first version used docker. That one was squashed for this version which uses podman.