### PR TITLE
check for cluster status and artifacts before cleanup

### DIFF
--- a/OCP-4.X/install-on-aws.yml
+++ b/OCP-4.X/install-on-aws.yml
@@ -25,7 +25,7 @@
     - role: cerberus
       when: cerberus_enable|bool
     - role: data_server_install
-      when: data_server_enable|bool            
+      when: data_server_enable|bool
 
 - name: (Optional) Debugging configuration of workload node
   hosts: workload

--- a/OCP-4.X/roles/cleanup-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-aws/tasks/main.yml
@@ -3,23 +3,27 @@
 # Clean up AWS install
 #
 
-- name: Check if a cluster is running
-  stat:
-    path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/metadata.json"
+- name: Check if cluster is running
+  shell: oc get clusterversion
+  ignore_errors: true
   register: cluster_status
 
-- block:
-    - name: Cleanup AWS cluster
-      shell: |
-        cd {{ansible_user_dir}}/scale-ci-deploy
-        bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
+- name: Check if scale-ci artifacts are present
+  stat:
+    path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/metadata.json"
+  register: cluster_artifacts
 
-    - name: Clean scale-ci-deploy openshift-install directories
-      become: true
-      file:
-        path: "{{item}}"
-        state: absent
-      with_items:
-        - "{{ansible_user_dir}}/scale-ci-deploy/bin"
-        - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws"
-  when: cluster_status.stat.exists == True
+- name: Cleanup AWS cluster
+  shell: |
+    cd {{ansible_user_dir}}/scale-ci-deploy
+    bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
+  when: cluster_artifacts.stat.exists == True and cluster_status.rc == 0
+
+- name: Clean scale-ci-deploy openshift-install directories
+  become: true
+  file:
+    path: "{{item}}"
+    state: absent
+  with_items:
+    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws"

--- a/OCP-4.X/roles/cleanup-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-azure/tasks/main.yml
@@ -1,25 +1,29 @@
 ---
 #
-# Clean up Azure IPI install
+# Clean up AZURE install
 #
 
-- name: Check if a cluster is running
-  stat:
-    path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/metadata.json"
+- name: Check if cluster is running
+  shell: oc get clusterversion
+  ignore_errors: true
   register: cluster_status
 
-- block:
-    - name: Cleanup Azure cluster
-      shell: |
-        cd {{ansible_user_dir}}/scale-ci-deploy
-        bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
+- name: Check if scale-ci artifacts are present
+  stat:
+    path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/metadata.json"
+  register: cluster_artifacts
 
-    - name: Clean scale-ci-deploy openshift-install directories
-      become: true
-      file:
-        path: "{{item}}"
-        state: absent
-      with_items:
-        - "{{ansible_user_dir}}/scale-ci-deploy/bin"
-        - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure"
-  when: cluster_status.stat.exists == True
+- name: Cleanup AZURE cluster
+  shell: |
+    cd {{ansible_user_dir}}/scale-ci-deploy
+    bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
+  when: cluster_artifacts.stat.exists == True and cluster_status.rc == 0
+
+- name: Clean scale-ci-deploy openshift-install directories
+  become: true
+  file:
+    path: "{{item}}"
+    state: absent
+  with_items:
+    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure"

--- a/OCP-4.X/roles/cleanup-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-gcp/tasks/main.yml
@@ -1,26 +1,31 @@
 ---
 #
-# Clean up GCP  IPI install
+# Clean up GCP install
 #
 
-- name: Check if a cluster is running
+- name: Check if cluster is running
+  shell: oc get clusterversion
+  ignore_errors: true
+  register: cluster_status
+
+- name: Check if scale-ci artifacts are present
   stat:
     path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/metadata.json"
-  register: cluster_status
+  register: cluster_artifacts
 
 - name: Cleanup GCP cluster
   shell: |
     cd {{ansible_user_dir}}/scale-ci-deploy
     export GOOGLE_CREDENTIALS={{ gcp_auth_key_file }}
     bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
+  when: cluster_artifacts.stat.exists == True and cluster_status.rc == 0
 
-- block:
-    - name: Clean scale-ci-deploy openshift-install directories
-      become: true
-      file:
-        path: "{{item}}"
-        state: absent
-      with_items:
-        - "{{ansible_user_dir}}/scale-ci-deploy/bin"
-        - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp"
-  when: cluster_status.stat.exists == True
+- name: Clean scale-ci-deploy openshift-install directories
+  become: true
+  file:
+    path: "{{item}}"
+    state: absent
+  with_items:
+    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp"
+


### PR DESCRIPTION
Fixes #81  

There are times when the cluster is pruned and the artifact (scale-ci-aws, bin) direcotries in scale-ci-deploy are not cleaned up. This PR will check if the cluster is running and only then will execute `destroy`. If the cluster is not running it will simply remove the artifact directories.
@chaitanyaenr 
