### PR TITLE
extend the life of Azure cluster and minor fixes

### DIFF
--- a/OCP-4.X/roles/post-config-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/post-config-on-azure/tasks/main.yml
@@ -27,7 +27,7 @@
 
 - name: Get node network security group
   shell: |
-    az network nsg list -g {{rhcos_cluster_name.stdout}}-rg --query "[].name" -o tsv | grep "node-nsg"
+    az network nsg list -g {{rhcos_cluster_name.stdout}}-rg --query "[].name" -o tsv | grep "nsg"
   register: azure_sg
 
 - name: Create network security group rule for ICMP
@@ -36,7 +36,7 @@
 
 - name: Create network security group rule for ssh (22)
   shell: |
-    az network nsg rule create -g {{rhcos_cluster_name.stdout}}-rg --name scale-ci-ssh --nsg-name {{azure_sg.stdout}} --priority 101 --access Allow --description "scale-ci allow ssh" --protocol Tcp --destination-port-ranges "22"
+    az network nsg rule create -g {{rhcos_cluster_name.stdout}}-rg --name scale-ci-ssh --nsg-name {{azure_sg.stdout}} --priority 103 --access Allow --description "scale-ci allow ssh" --protocol Tcp --destination-port-ranges "22"
 
 - name: Create network security group rule for pbench-agent ssh (2022)
   shell: |
@@ -52,6 +52,10 @@
 - name: Create network security group rule for tcp,udp hostnetwork tests (32768-60999)
   shell: |
     az network nsg rule create -g {{rhcos_cluster_name.stdout}}-rg --name scale-ci-hostnet --nsg-name {{azure_sg.stdout}} --priority 106 --access Allow --description "scale-ci allow tcp,udp hostnetwork tests" --protocol "*" --destination-port-ranges "32768-60999"
+
+- name: Append a tag to the resource group to extend the lifetime of the cluster to 40 days
+  shell: |
+    az group update -n {{rhcos_cluster_name.stdout}}-rg --set tags.'openshift_expiryDate'=$(date -d "+40 days" +%F)
 
 - name: Get the kubeconfig off of the orchestration host
   fetch:


### PR DESCRIPTION
change priority of scale-ci-ssh to 103 as 
```
root@: ~ #  az network nsg rule create -g  perfciazure-xxxxx-rg --name scale-ci-ssh --nsg-name perfciazure-xxxxx-nsg --priority 101 --access Allow --description "scale-ci allow ssh" --protocol Tcp --destination-port-ranges "22"
Security rule apiserver_in conflicts with rule scale-ci-ssh. Rules cannot have the same Priority and Direction.
```
grep for nsg as
```
root@: ~ # az network nsg list -g perfciazure-xxxxx-rg --query "[].name" -o tsv | grep "nsg" 
perfciazure-xxxxx-nsg
```
and add `openshift_expiryDate` to extend the expiry from 2 days to 40 days

![image](https://user-images.githubusercontent.com/53906986/89450746-0a05ba80-d729-11ea-9e30-7cd0c0fda4d4.png)

@chaitanyaenr @dry923 