### PR TITLE
reverting to old cleanup method as we have an azure pruning fix

### DIFF
--- a/OCP-4.X/roles/cleanup-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-aws/tasks/main.yml
@@ -3,27 +3,22 @@
 # Clean up AWS install
 #
 
-- name: Check if cluster is running
-  shell: oc get clusterversion
-  ignore_errors: true
-  register: cluster_status
-
-- name: Check if scale-ci artifacts are present
+- name: Check if a cluster is running
   stat:
     path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/metadata.json"
-  register: cluster_artifacts
+  register: cluster_status
 
-- name: Cleanup AWS cluster
-  shell: |
-    cd {{ansible_user_dir}}/scale-ci-deploy
-    bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
-  when: cluster_artifacts.stat.exists == True and cluster_status.rc == 0
-
-- name: Clean scale-ci-deploy openshift-install directories
-  become: true
-  file:
-    path: "{{item}}"
-    state: absent
-  with_items:
-    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
-    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws"
+- block:
+    - name: Cleanup AWS cluster
+      shell: |
+        cd {{ansible_user_dir}}/scale-ci-deploy
+        bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws/
+    - name: Clean scale-ci-deploy openshift-install directories
+      become: true
+      file:
+        path: "{{item}}"
+        state: absent
+      with_items:
+        - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+        - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-aws"
+  when: cluster_status.stat.exists == True

--- a/OCP-4.X/roles/cleanup-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-azure/tasks/main.yml
@@ -1,29 +1,24 @@
 ---
 #
-# Clean up AZURE install
+# Clean up Azure IPI install
 #
 
-- name: Check if cluster is running
-  shell: oc get clusterversion
-  ignore_errors: true
-  register: cluster_status
-
-- name: Check if scale-ci artifacts are present
+- name: Check if a cluster is running
   stat:
     path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/metadata.json"
-  register: cluster_artifacts
+  register: cluster_status
 
-- name: Cleanup AZURE cluster
-  shell: |
-    cd {{ansible_user_dir}}/scale-ci-deploy
-    bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
-  when: cluster_artifacts.stat.exists == True and cluster_status.rc == 0
-
-- name: Clean scale-ci-deploy openshift-install directories
-  become: true
-  file:
-    path: "{{item}}"
-    state: absent
-  with_items:
-    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
-    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure"
+- block:
+    - name: Cleanup Azure cluster
+      shell: |
+        cd {{ansible_user_dir}}/scale-ci-deploy
+        bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure/
+    - name: Clean scale-ci-deploy openshift-install directories
+      become: true
+      file:
+        path: "{{item}}"
+        state: absent
+      with_items:
+        - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+        - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-azure"
+  when: cluster_status.stat.exists == True

--- a/OCP-4.X/roles/cleanup-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/cleanup-on-gcp/tasks/main.yml
@@ -1,31 +1,25 @@
 ---
 #
-# Clean up GCP install
+# Clean up GCP  IPI install
 #
 
-- name: Check if cluster is running
-  shell: oc get clusterversion
-  ignore_errors: true
-  register: cluster_status
-
-- name: Check if scale-ci artifacts are present
+- name: Check if a cluster is running
   stat:
     path: "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/metadata.json"
-  register: cluster_artifacts
+  register: cluster_status
 
 - name: Cleanup GCP cluster
   shell: |
     cd {{ansible_user_dir}}/scale-ci-deploy
     export GOOGLE_CREDENTIALS={{ gcp_auth_key_file }}
     bin/openshift-install destroy cluster --log-level=debug --dir={{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp/
-  when: cluster_artifacts.stat.exists == True and cluster_status.rc == 0
-
-- name: Clean scale-ci-deploy openshift-install directories
-  become: true
-  file:
-    path: "{{item}}"
-    state: absent
-  with_items:
-    - "{{ansible_user_dir}}/scale-ci-deploy/bin"
-    - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp"
-
+- block:
+    - name: Clean scale-ci-deploy openshift-install directories
+      become: true
+      file:
+        path: "{{item}}"
+        state: absent
+      with_items:
+        - "{{ansible_user_dir}}/scale-ci-deploy/bin"
+        - "{{ansible_user_dir}}/scale-ci-deploy/scale-ci-gcp"
+  when: cluster_status.stat.exists == True


### PR DESCRIPTION
azure pruning fix in the subject https://github.com/openshift-scale/scale-ci-deploy/commit/80ea4ff31d5dcff1429c727e2797d8873f2fbe37#diff-fde0c50d2fc6976fb63965ebfef2f500R56

edge case missed
cleanup is skipped (cluster!=Running) even when the metadata files are lying around (failed install)