### PR TITLE
Standardizing packages across the roles and adding in jq as a package

### DIFF
--- a/OCP-4.X/roles/install-on-aws/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-aws/tasks/main.yml
@@ -52,6 +52,7 @@
       - golang-bin
       - gcc-c++
       - python-pip
+      - jq
 
 - name: Install awscli
   pip:

--- a/OCP-4.X/roles/install-on-azure/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-azure/tasks/main.yml
@@ -55,6 +55,11 @@
       - azure-cli
       - golang
       - golang-bin
+      - gcc
+      - git
+      - gcc-c++
+      - python-pip
+      - jq
 
 - name: Use installer from a build
   block:

--- a/OCP-4.X/roles/install-on-gcp/tasks/main.yml
+++ b/OCP-4.X/roles/install-on-gcp/tasks/main.yml
@@ -56,6 +56,11 @@
       - google-cloud-sdk
       - golang
       - golang-bin
+      - gcc
+      - git
+      - gcc-c++
+      - python-pip
+      - jq
 
 - name: Use installer from a build
   block:


### PR DESCRIPTION
JQ is needed by the installer and isn't listed in the package requirements. I also standardized them across the cloud roles.