### PR TITLE
Update dittybopper URL

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -293,12 +293,12 @@
   block:
     - name: clone dittybopper
       git:
-        repo: 'https://github.com/cloud-bulldozer/dittybopper.git'
-        dest: "{{ansible_user_dir}}/dittybopper"
+        repo: 'https://github.com/cloud-bulldozer/performance-dashboards.git'
+        dest: "{{ansible_user_dir}}/performance-dashboards"
         force: yes
 
     - name: Deploy mutable Grafana
       command: ./deploy.sh
       args:
-        chdir: "{{ansible_user_dir}}/dittybopper"
+        chdir: "{{ansible_user_dir}}/performance-dashboards/dittybopper"
   when: dittybopper_enable


### PR DESCRIPTION
Dittybopper has been merged with arsenal at https://github.com/cloud-bulldozer/performance-dashboards.git

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>