### PR TITLE
Updating userDataSecret name from machinesets

### DIFF
--- a/OCP-4.X/roles/post-install/tasks/main.yml
+++ b/OCP-4.X/roles/post-install/tasks/main.yml
@@ -13,6 +13,14 @@
     {%raw%}oc get machineset -n openshift-machine-api -o=go-template='{{(index (index .items 0).metadata.labels {%endraw%} "{{ machineset_metadata_label_prefix }}/cluster-api-cluster" {%raw%})}}'{%endraw%}
   register: cluster_name
 
+- name: Get cluster version
+  command: {%raw%}oc get clusterversion version -o go-template --template="{{.status.desired.version}}"{%endraw%}
+  register: ocp_version
+
+- name: Set userDataSecret name
+  set_fact:
+    user_data_secret: {% if ocp_version is version('4.6', '>=')%}worker-user-data-managed{% else %}worker-user-data{% endif %}
+
 - name: Add Index install timings to Elasticsearch
   copy:
     src: index-install-data.sh

--- a/OCP-4.X/roles/post-install/templates/aws-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/aws-infra-node-machineset.yml.j2
@@ -66,7 +66,7 @@ items:
             - name: kubernetes.io/cluster/{{cluster_name.stdout}}
               value: owned
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
         versions:
           kubelet: ""
   status:
@@ -137,7 +137,7 @@ items:
             - name: kubernetes.io/cluster/{{cluster_name.stdout}}
               value: owned
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
         versions:
           kubelet: ""
   status:
@@ -208,7 +208,7 @@ items:
             - name: kubernetes.io/cluster/{{cluster_name.stdout}}
               value: owned
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
         versions:
           kubelet: ""
   status:

--- a/OCP-4.X/roles/post-install/templates/aws-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/aws-workload-node-machineset.yml.j2
@@ -66,7 +66,7 @@ items:
             - name: kubernetes.io/cluster/{{cluster_name.stdout}}
               value: owned
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
         versions:
           kubelet: ""
   status:

--- a/OCP-4.X/roles/post-install/templates/azure-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/azure-infra-node-machineset.yml.j2
@@ -61,7 +61,7 @@ items:
             sshPublicKey: ""
             subnet: {{cluster_name.stdout}}-worker-subnet
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
             vmSize: {{openshift_infra_node_vm_size}}
             vnet: {{cluster_name.stdout}}-vnet
             zone: "1"
@@ -128,7 +128,7 @@ items:
             sshPublicKey: ""
             subnet: {{cluster_name.stdout}}-worker-subnet
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
             vmSize: {{openshift_infra_node_vm_size}}
             vnet: {{cluster_name.stdout}}-vnet
             zone: "2"
@@ -195,7 +195,7 @@ items:
             sshPublicKey: ""
             subnet: {{cluster_name.stdout}}-worker-subnet
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
             vmSize: {{openshift_infra_node_vm_size}}
             vnet: {{cluster_name.stdout}}-vnet
             zone: "3"

--- a/OCP-4.X/roles/post-install/templates/azure-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/azure-workload-node-machineset.yml.j2
@@ -61,7 +61,7 @@ items:
             sshPublicKey: ""
             subnet: {{cluster_name.stdout}}-worker-subnet
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
             vmSize: {{openshift_workload_node_vm_size}}
             vnet: {{cluster_name.stdout}}-vnet
             zone: "1"

--- a/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-infra-node-machineset.yml.j2
@@ -60,7 +60,7 @@ items:
             tags:
             - {{cluster_name.stdout}}-worker
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
             zone: {{ gcp_region }}-a
   status:
     replicas: 1
@@ -124,7 +124,7 @@ items:
             tags:
             - {{cluster_name.stdout}}-worker
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
             zone: {{ gcp_region }}-b
   status:
     replicas: 1
@@ -188,7 +188,7 @@ items:
             tags:
             - {{cluster_name.stdout}}-worker
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
             zone: {{ gcp_region }}-c
   status:
     replicas: 1

--- a/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/gcp-workload-node-machineset.yml.j2
@@ -59,7 +59,7 @@ spec:
           tags:
           - {{cluster_name.stdout}}-worker
           userDataSecret:
-            name: worker-user-data
+            name: {{ user_data_secret }}
           zone: {{ gcp_region }}-a
 status:
   replicas: 1

--- a/OCP-4.X/roles/post-install/templates/osp-infra-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/osp-infra-node-machineset.yml.j2
@@ -57,7 +57,7 @@ items:
             - openshiftClusterID={{cluster_name.stdout}}
             trunk: true
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
         versions:
           kubelet: ""
   status:

--- a/OCP-4.X/roles/post-install/templates/osp-workload-node-machineset.yml.j2
+++ b/OCP-4.X/roles/post-install/templates/osp-workload-node-machineset.yml.j2
@@ -57,7 +57,7 @@ items:
             - openshiftClusterID={{cluster_name.stdout}}
             trunk: true
             userDataSecret:
-              name: worker-user-data
+              name: {{ user_data_secret }}
         versions:
           kubelet: ""
   status:


### PR DESCRIPTION
The old name is not valid anymore, updating it to `worker-user-data-managed`

Signed-off-by: Raul Sevilla <rsevilla@redhat.com>