### PR TITLE
Add support to build trigger to capture cluster state

### DIFF
--- a/OCP-4.X/build-info-inventory.example
+++ b/OCP-4.X/build-info-inventory.example
@@ -1,0 +1,5 @@
+[orchestration]
+# The server to host the build status
+
+[cluster_host]
+# The server that is expected to host the oc client and kubeconfig

--- a/OCP-4.X/build-info.yml
+++ b/OCP-4.X/build-info.yml
@@ -107,3 +107,19 @@
             force: yes
           when: not job_status.content | b64decode | trim | bool
       when: job_status_file.stat.exists == True
+
+    - name: check if the cluster is running
+      shell: oc get clusterversion
+      register: cluster_version
+      ignore_errors: yes
+      delegate_to: "{{ groups['cluster_host'][0] }}"
+
+    - name: set cluster status as fact
+      set_fact: 
+        cluster_status: "{% if cluster_version.rc == 0 %}true{% else %}false{% endif %}"
+
+    - name: update the cluster status
+      copy:
+        content: "{{ cluster_status }}"
+        dest: "{{ build_info_destination }}/cluster.status"
+        force: yes


### PR DESCRIPTION
This commit enables build trigger to check the cluster state and
set the status for the install jobs to query in addition to the
build info and act accordingly.